### PR TITLE
Add initial `Tap` tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,9 +35,9 @@ Note that this library is currently a work in progress--more platforms will be s
 | Supports multiple TUN/TAP creation          | ✅        | Not on Windows | ✅               | ✅         | ✅        | ✅          |
 | IPv4 routing support                        | Planned   | ✅             | ✅               | ⬜         | ⬜        | ✅          |
 | IPv6 routing support                        | Planned   | ⬜             | Linux only       | ⬜         | ⬜        | ⬜          |
-| Unit testing for `TUN` devices              | Planned   | ✅             | ✅               | ✅         | ✅        | ⬜          |
-| Unit testing for `TAP` devices              | Planned   | ⬜             | ⬜               | ⬜         | ⬜        | ⬜          |
-| Cross-platform CI tests                     | Planned   | ⬜             | ⬜               | N/A        | ⬜        | N/A         |
+| Unit testing for `TUN` devices              | ✅        | ✅             | ✅               | ✅         | ✅        | ⬜          |
+| Unit testing for `TAP` devices              | ✅        | ⬜             | ⬜               | ⬜         | ⬜        | ⬜          |
+| Cross-platform CI tests                     | ✅        | ⬜             | ⬜               | N/A        | ⬜        | N/A         |
 | TUN/TAP support for Linux                   | ✅        | TUN only       | TUN only         | ✅         | ✅        | ✅          |
 | TUN/TAP support for MacOS                   | ✅        | TUN only       | TUN only         | ⬜         | TUN only  | ⬜          |
 | TUN/TAP support for Windows                 | TUN only  | TUN only       | TUN only         | ⬜         | ⬜        | ⬜          |

--- a/src/linux.rs
+++ b/src/linux.rs
@@ -168,54 +168,54 @@ impl TunImpl {
 }
 
 pub(crate) struct TapImpl {
-    tun: Tap,
+    tap: Tap,
 }
 
 impl TapImpl {
     #[inline]
     pub fn new() -> io::Result<Self> {
-        Ok(Self { tun: Tap::new()? })
+        Ok(Self { tap: Tap::new()? })
     }
 
     #[inline]
     pub fn new_named(if_name: Interface) -> io::Result<Self> {
         Ok(Self {
-            tun: Tap::new_named(if_name)?,
+            tap: Tap::new_named(if_name)?,
         })
     }
 
     #[inline]
     pub fn name(&self) -> io::Result<Interface> {
-        self.tun.name()
+        self.tap.name()
     }
 
     #[inline]
     pub fn set_state(&mut self, state: DeviceState) -> io::Result<()> {
-        self.tun.set_state(state)
+        self.tap.set_state(state)
     }
 
     #[inline]
     pub fn mtu(&self) -> io::Result<usize> {
-        self.tun.mtu()
+        self.tap.mtu()
     }
 
     #[inline]
     pub fn set_nonblocking(&mut self, nonblocking: bool) -> io::Result<()> {
-        self.tun.set_nonblocking(nonblocking)
+        self.tap.set_nonblocking(nonblocking)
     }
 
     #[inline]
     pub fn nonblocking(&self) -> io::Result<bool> {
-        self.tun.nonblocking()
+        self.tap.nonblocking()
     }
 
     #[inline]
     pub fn send(&mut self, buf: &[u8]) -> io::Result<usize> {
-        self.tun.send(buf)
+        self.tap.send(buf)
     }
 
     #[inline]
     pub fn recv(&mut self, buf: &mut [u8]) -> io::Result<usize> {
-        self.tun.recv(buf)
+        self.tap.recv(buf)
     }
 }

--- a/src/tap.rs
+++ b/src/tap.rs
@@ -89,3 +89,31 @@ impl Tap {
         self.inner.recv(buf)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn unique_names() {
+        let tap1 = Tap::new().unwrap();
+        let tap2 = Tap::new().unwrap();
+        let tap3 = Tap::new().unwrap();
+
+        let tap1_name = tap1.name().unwrap();
+        let tap2_name = tap2.name().unwrap();
+        let tap3_name = tap3.name().unwrap();
+
+        assert!(tap1_name != tap2_name);
+        assert!(tap1_name != tap3_name);
+        assert!(tap2_name != tap3_name);
+    }
+
+    #[test]
+    fn up_down() {
+        let mut tap1 = Tap::new().unwrap();
+
+        tap1.set_up().unwrap();
+        tap1.set_down().unwrap();
+    }
+}


### PR DESCRIPTION
`Tun` interfaces have (basic) tests, now we want to do the same for `Tap` interfaces.