### PR TITLE
Lower MSRV to 1.66

### DIFF
--- a/.github/workflows/full_ci.yml
+++ b/.github/workflows/full_ci.yml
@@ -27,7 +27,7 @@ jobs:
       matrix:
         toolchain:
           - stable
-          - 1.74.0
+          - 1.66.0
     steps:
       - uses: actions/checkout@v4
       - name: Setup Rust toolchain
@@ -45,7 +45,7 @@ jobs:
       matrix:
         target:
           - { toolchain: stable, os: macos-14 }
-          - { toolchain: 1.74.0, os: macos-14 }
+          - { toolchain: 1.66.0, os: macos-14 }
     runs-on: ${{ matrix.target.os }}
     steps:
       - uses: actions/checkout@v4
@@ -63,8 +63,8 @@ jobs:
       fail-fast: true
       matrix:
         toolchain:
-          - 1.74.0
           - stable
+          - 1.66.0
         target:
           - x86_64-pc-windows-msvc
     steps:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,8 +3,7 @@ name = "tappers"
 authors = ["Nathaniel Bennett <me[at]nathanielbennett[dotcom]>"]
 description = "Cross-platform TUN and TAP interfaces"
 # 1.66 - `std::os::fd` stabilized
-# 1.74 - `OsStr::as_encoded_bytes` stabilized
-rust-version = "1.74" 
+rust-version = "1.66" 
 version = "0.1.0"
 license = "MIT OR Apache-2.0"
 edition = "2021"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -142,8 +142,7 @@ impl Interface {
     #[cfg(not(target_os = "windows"))]
     #[inline]
     fn new_inner(if_name: &impl AsRef<OsStr>) -> io::Result<Self> {
-        // Note: `as_encoded_bytes()` is the only think keeping MSRV as high as 1.74
-        Self::new_raw(if_name.as_ref().as_encoded_bytes())
+        Self::new_raw(if_name.as_ref().as_bytes())
     }
 
     #[cfg(not(target_os = "windows"))]


### PR DESCRIPTION
The current MSRV of 1.74 is based on the need for `OsStr::as_encoded_bytes()`. Given that `OsStrExt::to_bytes()` fulfills the same need and the context is Unix-specific, we can remove this API and lower the MSRV to 1.66 (which we need for `RawFd`).