### PR TITLE
Simplify Windows CI; add checks on push to main

### DIFF
--- a/.github/workflows/full_ci.yml
+++ b/.github/workflows/full_ci.yml
@@ -1,6 +1,8 @@
 name: full CI
 
 on:
+  push:
+    branches: [ "master" ]
   merge_group:
   pull_request:
     types: [opened, synchronize, reopened]

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ be installed; otherwise, instantiation of `Tun` and `Tap` types will fail with a
 MacOS provides a kind of TUN interface via the `utun` API, which acts mostly the same as `tun` on
 other platforms. While MacOS has no explicit `tap` API, it does have a relatively-undocumented
 `feth` interface (see
-(if_fake.c)[https://github.com/apple-oss-distributions/xnu/blob/main/bsd/net/if_fake.c]) that is
+[if_fake.c](https://github.com/apple-oss-distributions/xnu/blob/main/bsd/net/if_fake.c)) that is
 nearly equivalent in functionality to TAP interfaces. Despite its missing documentation, `feth`
 interfaces are supported in MacOS releases as early as 10.13 (High Sierra), and their API has
 remained relatively stable since its inception.

--- a/ci/install-rust.sh
+++ b/ci/install-rust.sh
@@ -32,25 +32,6 @@ if [ -n "$INSTALL_RUST_SRC" ]; then
 fi
 
 if [ "$OS" = "windows" ]; then
-  if [ "$ARCH_BITS" = "i686" ]; then
-    echo "Install MinGW32"
-    choco install mingw --x86 --force
-  fi
-
-  echo "Find GCC libraries"
-  gcc -print-search-dirs
-  /usr/bin/find "C:\ProgramData\Chocolatey" -name "crt2*"
-  /usr/bin/find "C:\ProgramData\Chocolatey" -name "dllcrt2*"
-  /usr/bin/find "C:\ProgramData\Chocolatey" -name "libmsvcrt*"
-
-  if [ -n "$ARCH_BITS" ]; then
-    echo "Fix MinGW"
-    for i in crt2.o dllcrt2.o libmingwex.a libmsvcrt.a ; do
-      cp -f "/C/ProgramData/Chocolatey/lib/mingw/tools/install/mingw$ARCH_BITS/$ARCH-w64-mingw32/lib/$i" "$(rustc --print sysroot)/lib/rustlib/$TARGET/lib"
-    done
-  fi
-
-  # Install Wintun
   echo "Install Wintun"
   curl.exe -o wintun.zip https://www.wintun.net/builds/wintun-0.14.1.zip
   powershell.exe -NoP -NonI -Command "Expand-Archive './wintun.zip' './'"


### PR DESCRIPTION
Removes unneccessary MinGW installation and enforces checks on push to the primary branch.