### PR TITLE
Remove serial_tests crate for RUST_TEST_THREADS

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -4,3 +4,5 @@ runner = 'sudo -E'
 [target.'cfg(windows)']
 runner = "powershell -Command Start-Process -Verb runAs -FilePath"
 
+[env]
+RUST_TEST_THREADS = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,3 @@ libc = { version = "0.2" }
 windows-sys = { version = "0.59", features = ["Win32", "Win32_NetworkManagement", "Win32_NetworkManagement_IpHelper", "Win32_NetworkManagement_Ndis", "Win32_System", "Win32_System_LibraryLoader", "Win32_System_Threading"] }
 # To be removed once nightly OnceCell APIs are stabilized
 once_cell = { version = "1.19" }
-
-[dev-dependencies]
-serial_test = "3.1.1"

--- a/src/tap.rs
+++ b/src/tap.rs
@@ -111,10 +111,8 @@ impl Tap {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use serial_test::serial;
 
     #[test]
-    #[serial]
     fn unique_names() {
         let tap1 = Tap::new().unwrap();
         let tap2 = Tap::new().unwrap();
@@ -130,7 +128,6 @@ mod tests {
     }
 
     #[test]
-    #[serial]
     fn up_down() {
         let mut tap1 = Tap::new().unwrap();
 
@@ -139,7 +136,6 @@ mod tests {
     }
 
     #[test]
-    #[serial]
     fn exists() {
         let tap1 = Tap::new().unwrap();
         let tap1_name = tap1.name().unwrap();
@@ -147,7 +143,6 @@ mod tests {
     }
 
     #[test]
-    #[serial]
     fn not_persistent() {
         let tap1 = Tap::new().unwrap();
 

--- a/src/tun.rs
+++ b/src/tun.rs
@@ -114,10 +114,8 @@ impl Tun {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use serial_test::serial;
 
     #[test]
-    #[serial]
     fn unique_names() {
         let tun1 = Tun::new().unwrap();
         let tun2 = Tun::new().unwrap();
@@ -133,7 +131,6 @@ mod tests {
     }
 
     #[test]
-    #[serial]
     fn up_down() {
         let mut tun1 = Tun::new().unwrap();
 
@@ -142,7 +139,6 @@ mod tests {
     }
 
     #[test]
-    #[serial]
     fn exists() {
         let tun1 = Tun::new().unwrap();
         let tun1_name = tun1.name().unwrap();
@@ -150,7 +146,6 @@ mod tests {
     }
 
     #[test]
-    #[serial]
     fn not_persistent() {
         let tun1 = Tun::new().unwrap();
 


### PR DESCRIPTION
There's no need to have `serial_tests` as a dev dependency, as the `RUST_TEST_THREADS` env variable does the same thing.