### PR TITLE
Implement TUN/TAP for *BSD systems

### DIFF
--- a/.github/workflows/full_ci.yml
+++ b/.github/workflows/full_ci.yml
@@ -78,6 +78,130 @@ jobs:
         run: TOOLCHAIN=${{ matrix.toolchain }} sh ./ci/run.sh
         shell: bash
 
+  build_channels_openbsd:
+    name: Build Channels OpenBSD
+    runs-on: ubuntu-latest
+    env:
+      OS: openbsd
+    strategy:
+      fail-fast: true
+      matrix:
+        toolchain:
+          - stable # Note: not actually stable, just current rustc version for OpenBSD 7.5
+    steps:
+    - uses: actions/checkout@v4
+    - name: Test in OpenBSD
+      id: openbsd-ci
+      uses: vmactions/openbsd-vm@v1
+      with:
+        release: "7.5"
+        envs: 'OS'
+        usesh: true
+        prepare: |
+          pkg_add curl
+          pkg_add sudo-1.9.15.5
+          pkg_add rust
+        run: |
+          TOOLCHAIN=${{ matrix.toolchain }} sh ./ci/run.sh
+
+  build_channels_freebsd:
+    name: Build Channels FreeBSD
+    runs-on: ubuntu-latest
+    env:
+      OS: freebsd
+    strategy:
+      fail-fast: true
+      matrix:
+        toolchain:
+          - stable
+          - 1.66.0
+    steps:
+    - uses: actions/checkout@v4
+    - name: Test in FreeBSD
+      id: freebsd-ci
+      uses: vmactions/freebsd-vm@v1
+      with:
+        envs: 'OS'
+        usesh: true
+        prepare: |
+          pkg install -y curl
+          pkg install -y sudo
+          curl https://sh.rustup.rs -sSf | sh -s -- -y
+        run: |
+          export PATH="$HOME/.cargo/bin:$PATH"
+          TARGET=${{ matrix.target }} sh ./ci/install-rust.sh
+          TOOLCHAIN=${{ matrix.toolchain }} sh ./ci/run.sh
+
+  build_channels_netbsd:
+    name: Build Channels NetBSD
+    runs-on: ubuntu-latest
+    env:
+      DEBUG: 1
+      OS: netbsd
+    strategy:
+      fail-fast: true
+      matrix:
+        toolchain:
+          - stable
+          - 1.66.0
+    steps:
+    - uses: actions/checkout@v4
+    - name: Test in NetBSD
+      id: netbsd-ci
+      uses: vmactions/netbsd-vm@v1
+      with:
+        envs: 'DEBUG OS'
+        usesh: true
+        prepare: |
+          /usr/sbin/pkg_add curl
+          /usr/sbin/pkg_add sudo
+
+          curl https://sh.rustup.rs -sSf | sh -s -- -y
+        run: |
+          export PATH="$HOME/.cargo/bin:$PATH"
+          TARGET=${{ matrix.target }} sh ./ci/install-rust.sh
+          TOOLCHAIN=${{ matrix.toolchain }} sh ./ci/run.sh
+
+
+# FreeBSD:
+# kldload -n -v if_tuntap
+# NetBSD:
+# /sbin/modload if_tuntap
+
+#   Disabled for now due to lack of `rustup` support:
+#   https://github.com/rust-lang/rustup/issues/2168
+#
+#   If this changes, we may enable OpenBSD CI
+
+#  build_channels_openbsd:
+#    name: Build Channels OpenBSD
+#    runs-on: ubuntu-latest
+#    env:
+#      OS: openbsd
+#    strategy:
+#      fail-fast: true
+#      matrix:
+#        toolchain:
+#          - stable
+#          - 1.66.0
+#    steps:
+#    - uses: actions/checkout@v4
+#    - name: Test in OpenBSD
+#      id: test
+#      uses: vmactions/openbsd-vm@v1
+#      with:
+#        envs: 'OS'
+#        usesh: true
+#        prepare: |
+#          pkg_add curl
+#          pkg_add sudo-1.9.15.5
+#          /sbin/modload if_tuntap
+#          curl https://sh.rustup.rs -sSf | sh -s -- -y
+#        run: |
+#          export PATH="$HOME/.cargo/bin:$PATH"
+#          TARGET=${{ matrix.target }} sh ./ci/install-rust.sh
+#          TOOLCHAIN=${{ matrix.toolchain }} sh ./ci/run.sh
+
   check_cfg:
     name: "Check #[cfg]s"
     runs-on: ubuntu-22.04
@@ -106,3 +230,6 @@ jobs:
       # Manually check the status of all dependencies. `if: failure()` does not work.
       - name: check if any dependency failed
         run: jq --exit-status 'all(.result == "success")' <<< '${{ toJson(needs) }}'
+
+# TODO: when it comes time to add Solaris/IllumOS, add this to install TUN/TAP driver:
+# `pkg-get install tap`

--- a/README.md
+++ b/README.md
@@ -4,25 +4,23 @@
 
 **Tappers is a library for creating, managing and exchanging packets on TUN/TAP interfaces.**
 
-`tappers` provides both platform-specific and cross-platform APIs for managing TUN and TAP
-devices. It supports the following features for each platform:
+`tappers` provides both platform-specific and cross-platform APIs for managing TUN/TAP devices and
+virtual ethernet pairs. It supports the following features for each platform:
 
-| Platform | TUN  | TAP | Kernel BPF |
-| -------- | ---- | --- | ---------- |
-| Linux    | ✅   | ✅  | ⬜         |
-| MacOS    | ✅   | ✅  | ⬜         |
-| Windows  | ✅   | ⬜  | N/A        |
-| FreeBSD  | ⬜   | ⬜  | ⬜         |
-| OpenBSD  | ⬜   | ⬜  | ⬜         |
-| NetBSD   | ⬜   | ⬜  | ⬜         |
-| Solaris  | ⬜   | ⬜  | ⬜         |
-| IllumOS  | ⬜   | ⬜  | ⬜         |
-| Android  | ⬜ * | ⬜* | N/A        |
-| iOS      | ⬜   | N/A | N/A        |
+| Platform      | TUN  | TAP | vETH |
+| ------------- | ---- | --- | ---- |
+| Linux         | ✅   | ✅  | ⬜   |
+| MacOS         | ✅   | ✅  | ⬜   |
+| Windows       | ✅   | ⬜  | N/A  |
+| FreeBSD       | ✅   | ✅  | ⬜   |
+| OpenBSD       | ✅   | ✅  | ⬜   |
+| NetBSD        | ✅   | ✅  | ⬜   |
+| DragonFly BSD | ✅   | ✅  | N/A  |
+| Solaris       | ⬜   | ⬜  | N/A  |
+| IllumOS       | ⬜   | ⬜  | N/A  |
+| AIX           | ⬜   | ⬜  | N/A  |
 
-`N/A` - platform does not support specified feature
-
-`*` - only supported on rooted Android
+`N/A` - platform does not have any virtual Ethernet implementation.
 
 Note that this library is currently a work in progress--more platforms will be supported soon!
 
@@ -41,14 +39,14 @@ Note that this library is currently a work in progress--more platforms will be s
 | TUN/TAP support for Linux                   | ✅        | TUN only       | TUN only         | ✅         | ✅        | ✅          |
 | TUN/TAP support for MacOS                   | ✅        | TUN only       | TUN only         | ⬜         | TUN only  | ⬜          |
 | TUN/TAP support for Windows                 | TUN only  | TUN only       | TUN only         | ⬜         | ⬜        | ⬜          |
-| TUN/TAP support for *BSD                    | Planned   | ⬜             | FreeBSD/TUN only | ⬜         | OpenBSD   | ⬜          |
+| TUN/TAP support for *BSD                    | ✅        | ⬜             | FreeBSD/TUN only | ⬜         | OpenBSD   | ⬜          |
 | TUN/TAP support for Solaris/IllumOS         | ⬜        | ⬜             | ⬜               | ⬜         | ⬜        | ⬜          |
 | non-`async` support                         | ✅        | ✅             | ✅               | ✅         | ✅        | ⬜          |
 | `async` support                             | Planned   | ✅             | Unix only        | ✅         | ⬜        | ✅          |
 
 ## Additional Notes on Platform Support
 
-Not all platforms implement the standard `/dev/net/tun` interface for TUN/TAP creation; there are
+Not all platforms implement the standard `/dev/tun` interface for TUN/TAP creation; there are
 special instances where TUN and TAP devices are provided either through the use of custom drivers
 (such as for Windows) or via special alternative network APIs (such as for MacOS). These are
 outlined below. The TL;DR is that *nix platforms are supported natively, Windows is supported
@@ -86,15 +84,16 @@ from the device is routed. If your intent is to create a VPN or proxy applicatio
 find `VpnService` to be better suited to your needs than this crate. Note that `VpnService` has
 no native API equivalent in Android, so `tappers` does not currently wrap it.
 
-For the (relatively slimmer) use case where users would like to run code on rooted Android devices,
-`tappers` provides bindings to Android's TUN/TAP interfaces.
-
 ### iOS
 
 iOS provides the `NEPacketTunnelProvider` API for VPN/proxy applications (similar to Android's
 `VpnProvider`). iOS does not support the creation of arbitrary TUN interfaces, and it provides no
 support for TAP interfaces. `NEPacketTunnelProvider` has no native API equivalent, so `tappers`
 does not currently wrap it.
+
+## Virtual Ethernet (vETH) Pairs
+
+Virtual Ethernet (or vETH) pairs can be thought of as a
 
 ## `async` Runtime Support
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,9 @@
 # Release History:
 
-* 0.1.1 (2023-03-23)
+* 0.2.0
+  - Add TUN/TAP support for *BSD variants
+
+* 0.1.1 (2024-09-17)
   - Fix bug in `Interface::new` method
   - Fix bug in getting/setting nonblocking for MacOS TUN, TAP
 

--- a/ci/run.sh
+++ b/ci/run.sh
@@ -12,18 +12,25 @@ RUST=${TOOLCHAIN}
 
 echo "Testing Rust ${RUST} on ${OS}"
 
-# FIXME: rustup often fails to download some artifacts due to network
-# issues, so we retry this N times.
-N=5
-n=0
-until [ $n -ge $N ]
-do
-    if rustup override set "${RUST}" ; then
-        break
-    fi
-    n=$((n+1))
-    sleep 1
-done
+case "${OS}" in
+    openbsd*)
+        # OpenBSD does not have rustup support
+        ;;
+    *)
+        # FIXME: rustup often fails to download some artifacts due to network
+        # issues, so we retry this N times.
+        N=5
+        n=0
+        until [ $n -ge $N ]
+        do
+            if rustup override set "${RUST}" ; then
+                break
+            fi
+            n=$((n+1))
+            sleep 1
+        done
+        ;;
+esac
 
 case "${OS}" in
     windows*)

--- a/src/freebsd.rs
+++ b/src/freebsd.rs
@@ -1,9 +1,0 @@
-// SPDX-License-Identifier: MIT OR Apache-2.0
-//
-// Copyright (c) 2024 Nathaniel Bennett <me[at]nathanielbennett[dotcom]>
-//
-// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
-// https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
-// <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
-// option. This file may not be copied, modified, or distributed
-// except according to those terms.

--- a/src/libc_extra.rs
+++ b/src/libc_extra.rs
@@ -1,0 +1,228 @@
+use std::mem;
+
+pub const IOCPARM_MASK: u64 = 0x1fff; // parameter length, at most 13 bits
+pub const IOCPARM_SHIFT: usize = 16;
+pub const IOCGROUP_SHIFT: usize = 8;
+
+#[allow(non_snake_case)]
+pub const fn IOCPARM_LEN(x: u64) -> u64 {
+    (x >> IOCPARM_SHIFT) & IOCPARM_MASK
+}
+
+#[allow(non_snake_case)]
+pub const fn IOCBASECMD(x: u64) -> u64 {
+    x & !(IOCPARM_MASK << IOCPARM_SHIFT)
+}
+
+#[allow(non_snake_case)]
+pub const fn IOCGROUP(x: u64) -> u64 {
+    ((x) >> IOCGROUP_SHIFT) & 0xff
+}
+
+pub const IOC_VOID: u64 = 0x20000000; // no parameters
+pub const IOC_OUT: u64 = 0x40000000; // copy parameters out
+pub const IOC_IN: u64 = 0x80000000; // copy parameters in
+pub const IOC_INOUT: u64 = IOC_IN | IOC_OUT; // copy parameters in and out
+pub const IOC_DIRMASK: u64 = 0xe0000000; // mask for IN | OUT | VOID
+
+#[allow(non_snake_case)]
+pub const fn _IOC(inout: u64, group: u64, num: u64, len: usize) -> u64 {
+    inout
+        | (((len & (IOCPARM_MASK as usize)) as u64) << IOCPARM_SHIFT)
+        | (group << IOCGROUP_SHIFT)
+        | num
+}
+
+#[allow(non_snake_case)]
+pub const fn _IO(g: u8, n: u64) -> u64 {
+    _IOC(IOC_VOID, g as u64, n, 0)
+}
+
+#[allow(non_snake_case)]
+pub const fn _IOR<T: Sized>(g: u8, n: u64) -> u64 {
+    _IOC(IOC_OUT, g as u64, n, mem::size_of::<T>())
+}
+
+#[allow(non_snake_case)]
+pub const fn _IOW<T: Sized>(g: u8, n: u64) -> u64 {
+    _IOC(IOC_IN, g as u64, n, mem::size_of::<T>())
+}
+
+#[allow(non_snake_case)]
+pub const fn _IOWR<T: Sized>(g: u8, n: u64) -> u64 {
+    _IOC(IOC_INOUT, g as u64, n, mem::size_of::<T>())
+}
+
+#[cfg(any(target_os = "openbsd", target_os = "freebsd"))]
+#[allow(non_camel_case_types)]
+pub type caddr_t = *mut libc::c_char;
+
+#[cfg(target_os = "openbsd")]
+#[repr(C)]
+pub struct ifreq {
+    pub ifr_name: [libc::c_char; libc::IFNAMSIZ],
+    pub ifr_ifru: __c_anonymous_ifr_ifru,
+}
+
+#[cfg(target_os = "openbsd")]
+#[repr(C)]
+pub union __c_anonymous_ifr_ifru {
+    pub ifru_addr: libc::sockaddr,
+    pub ifru_dstaddr: libc::sockaddr,
+    pub ifru_broadaddr: libc::sockaddr,
+    pub ifru_flags: libc::c_short,
+    pub ifru_metric: libc::c_int,
+    pub ifru_mtu: libc::c_int,
+    pub ifru_vnetid: i64,
+    pub ifru_media: u64,
+    pub ifru_data: caddr_t, // MTU in `struct if_data`
+    pub ifru_index: libc::c_uint,
+}
+
+#[cfg(target_os = "freebsd")]
+#[repr(C)]
+pub struct ifreq {
+    pub ifr_name: [libc::c_char; libc::IFNAMSIZ],
+    pub ifr_ifru: __c_anonymous_ifr_ifru,
+}
+
+#[cfg(target_os = "freebsd")]
+#[repr(C)]
+pub union __c_anonymous_ifr_ifru {
+    pub ifru_addr: libc::sockaddr,
+    pub ifru_dstaddr: libc::sockaddr,
+    pub ifru_broadaddr: libc::sockaddr,
+    pub ifru_buffer: ifreq_buffer,
+    pub ifru_flags: [libc::c_short; 2],
+    pub ifru_index: libc::c_short,
+    pub ifru_jid: libc::c_int,
+    pub ifru_metric: libc::c_int,
+    pub ifru_mtu: libc::c_int,
+    pub ifru_phys: libc::c_int,
+    pub ifru_media: libc::c_int,
+    pub ifru_data: caddr_t,
+    pub ifru_cap: [libc::c_int; 2],
+    pub ifru_fib: libc::c_uint,
+    pub ifru_vlan_pcp: libc::c_uchar,
+    pub ifru_nv: ifreq_nv_req,
+}
+
+#[cfg(target_os = "freebsd")]
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct ifreq_nv_req {
+    pub buf_length: libc::c_uint,
+    pub length: libc::c_uint,
+    pub buffer: *mut libc::c_void,
+}
+
+#[cfg(target_os = "netbsd")]
+#[repr(C)]
+pub struct ifreq {
+    pub ifr_name: [libc::c_char; libc::IFNAMSIZ],
+    pub ifr_ifru: __c_anonymous_ifr_ifru,
+}
+
+#[cfg(target_os = "netbsd")]
+#[repr(C)]
+pub union __c_anonymous_ifr_ifru {
+    pub ifru_addr: libc::sockaddr,
+    pub ifru_dstaddr: libc::sockaddr,
+    pub ifru_broadaddr: libc::sockaddr,
+    pub ifru_space: libc::sockaddr_storage,
+    pub ifru_flags: libc::c_short,
+    pub ifru_addrflags: libc::c_int,
+    pub ifru_metric: libc::c_int,
+    pub ifru_mtu: libc::c_int,
+    pub ifru_dlt: libc::c_int,
+    pub ifru_value: libc::c_uint,
+    pub ifru_data: *mut libc::c_void,
+    pub ifru_b: __c_anonymous_ifru_b,
+}
+
+#[cfg(target_os = "dragonfly")]
+#[repr(C)]
+pub struct ifreq {
+    pub ifr_name: [libc::c_char; libc::IFNAMSIZ],
+    pub ifr_ifru: __c_anonymous_ifr_ifru,
+}
+
+#[cfg(target_os = "dragonfly")]
+#[repr(C)]
+pub union __c_anonymous_ifr_ifru {
+    pub ifru_addr: libc::sockaddr,
+    pub ifru_dstaddr: libc::sockaddr,
+    pub ifru_broadaddr: libc::sockaddr,
+    pub ifru_buffer: ifreq_buffer,
+    pub ifru_flags: [libc::c_short; 2],
+    pub ifru_index: libc::c_short,
+    pub ifru_metric: libc::c_int,
+    pub ifru_mtu: libc::c_int,
+    pub ifru_phys: libc::c_int,
+    pub ifru_media: libc::c_int,
+    pub ifru_data: *mut libc::c_void,
+    pub ifru_cap: [libc::c_int; 2],
+    pub ifru_pollcpu: libc::c_int,
+    pub ifru_tsolen: libc::c_int,
+}
+
+#[cfg(target_os = "netbsd")]
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct __c_anonymous_ifru_b {
+    pub b_buflen: u32,
+    pub b_buf: *mut libc::c_void,
+}
+
+#[cfg(any(target_os = "dragonfly", target_os = "freebsd"))]
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct ifreq_buffer {
+    pub length: libc::size_t,
+    pub buffer: *mut libc::c_void,
+}
+
+#[cfg(any(target_os = "dragonfly", target_os = "freebsd"))]
+extern "C" {
+    pub fn fdevname_r(
+        fd: libc::c_int,
+        buf: *mut libc::c_char,
+        len: libc::c_int,
+    ) -> *const libc::c_char;
+}
+
+#[cfg(any(target_os = "dragonfly", target_os = "openbsd", target_os = "netbsd"))]
+pub const SIOCIFCREATE: libc::c_ulong = _IOW::<ifreq>(b'i', 122);
+#[cfg(target_os = "freebsd")]
+pub const SIOCIFCREATE2: libc::c_ulong = _IOWR::<ifreq>(b'i', 124);
+#[cfg(any(
+    target_os = "dragonfly",
+    target_os = "freebsd",
+    target_os = "openbsd",
+    target_os = "netbsd"
+))]
+pub const SIOCIFDESTROY: libc::c_ulong = _IOW::<ifreq>(b'i', 121);
+#[cfg(any(
+    target_os = "dragonfly",
+    target_os = "freebsd",
+    target_os = "openbsd",
+    target_os = "netbsd"
+))]
+pub const SIOCGIFFLAGS: libc::c_ulong = _IOWR::<ifreq>(b'i', 17);
+#[cfg(any(
+    target_os = "dragonfly",
+    target_os = "freebsd",
+    target_os = "openbsd",
+    target_os = "netbsd"
+))]
+pub const SIOCSIFFLAGS: libc::c_ulong = _IOW::<ifreq>(b'i', 16);
+
+#[cfg(any(target_os = "dragonfly", target_os = "freebsd"))]
+pub const SIOCGIFMTU: libc::c_ulong = 0xc0906933;
+#[cfg(any(target_os = "openbsd", target_os = "netbsd"))]
+pub const SIOCGIFMTU: libc::c_ulong = _IOWR::<ifreq>(b'i', 126);
+
+#[cfg(any(target_os = "dragonfly", target_os = "freebsd"))]
+pub const SIOCSIFMTU: libc::c_ulong = 0x80906934;
+#[cfg(any(target_os = "openbsd", target_os = "netbsd"))]
+pub const SIOCSIFMTU: libc::c_ulong = _IOW::<ifreq>(b'i', 127);

--- a/src/netbsd.rs
+++ b/src/netbsd.rs
@@ -1,9 +1,0 @@
-// SPDX-License-Identifier: MIT OR Apache-2.0
-//
-// Copyright (c) 2024 Nathaniel Bennett <me[at]nathanielbennett[dotcom]>
-//
-// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
-// https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
-// <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
-// option. This file may not be copied, modified, or distributed
-// except according to those terms.

--- a/src/openbsd.rs
+++ b/src/openbsd.rs
@@ -1,9 +1,0 @@
-// SPDX-License-Identifier: MIT OR Apache-2.0
-//
-// Copyright (c) 2024 Nathaniel Bennett <me[at]nathanielbennett[dotcom]>
-//
-// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
-// https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
-// <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
-// option. This file may not be copied, modified, or distributed
-// except according to those terms.

--- a/src/solaris.rs
+++ b/src/solaris.rs
@@ -1,9 +1,0 @@
-// SPDX-License-Identifier: MIT OR Apache-2.0
-//
-// Copyright (c) 2024 Nathaniel Bennett <me[at]nathanielbennett[dotcom]>
-//
-// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
-// https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
-// <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
-// option. This file may not be copied, modified, or distributed
-// except according to those terms.

--- a/src/tap.rs
+++ b/src/tap.rs
@@ -16,6 +16,15 @@ use crate::{DeviceState, Interface};
 use crate::linux::TapImpl;
 #[cfg(target_os = "macos")]
 use crate::macos::TapImpl;
+#[cfg(any(
+    target_os = "dragonfly",
+    target_os = "freebsd",
+    target_os = "illumos",
+    target_os = "netbsd",
+    target_os = "openbsd",
+    target_os = "solaris"
+))]
+use crate::unix::TapImpl;
 
 /// A cross-platform TaP interface.
 pub struct Tap {
@@ -149,10 +158,10 @@ mod tests {
         let chosen_name = unsafe { CStr::from_ptr(b"tap24\0".as_ptr() as *const i8) };
 
         let iface = Interface::from_cstr(chosen_name).unwrap();
-        let tun = Tap::new_named(iface).unwrap();
-        let tun_iface = tun.name().unwrap();
+        let tap = Tap::new_named(iface).unwrap();
+        let tap_iface = tap.name().unwrap();
 
-        assert_eq!(chosen_name, tun_iface.name_cstr());
+        assert_eq!(chosen_name, tap_iface.name_cstr());
     }
 
     #[test]
@@ -168,6 +177,14 @@ mod tests {
         let tap1 = Tap::new().unwrap();
         let tap1_name = tap1.name().unwrap();
         assert!(tap1_name.exists().unwrap());
+    }
+
+    #[test]
+    fn not_exists() {
+        use std::ffi::OsStr;
+        let chosen_name = OsStr::new("tap24");
+        let iface = Interface::new(chosen_name).unwrap();
+        assert!(!iface.exists().unwrap());
     }
 
     #[test]

--- a/src/tun.rs
+++ b/src/tun.rs
@@ -16,6 +16,15 @@ use crate::{DeviceState, Interface};
 use crate::linux::TunImpl;
 #[cfg(target_os = "macos")]
 use crate::macos::TunImpl;
+#[cfg(any(
+    target_os = "dragonfly",
+    target_os = "freebsd",
+    target_os = "illumos",
+    target_os = "netbsd",
+    target_os = "openbsd",
+    target_os = "solaris"
+))]
+use crate::unix::TunImpl;
 #[cfg(target_os = "windows")]
 use crate::wintun::TunImpl;
 
@@ -171,6 +180,14 @@ mod tests {
         let tun1 = Tun::new().unwrap();
         let tun1_name = tun1.name().unwrap();
         assert!(tun1_name.exists().unwrap());
+    }
+
+    #[test]
+    fn not_exists() {
+        use std::ffi::OsStr;
+        let chosen_name = OsStr::new("tun24");
+        let iface = Interface::new(chosen_name).unwrap();
+        assert!(!iface.exists().unwrap());
     }
 
     #[test]

--- a/src/unix.rs
+++ b/src/unix.rs
@@ -1,0 +1,133 @@
+//! TUN/TAP interface for various Unix systems (*BSD variants, Solaris, IllumOS).
+//!
+//!
+//!
+//!
+
+pub mod tap;
+pub mod tun;
+
+pub use tap::Tap;
+pub use tun::Tun;
+
+use std::io;
+use std::ptr;
+
+use crate::libc_extra::*;
+use crate::{DeviceState, Interface};
+
+#[inline]
+pub(crate) fn ifreq_empty() -> ifreq {
+    ifreq {
+        ifr_name: [0; libc::IFNAMSIZ],
+        ifr_ifru: __c_anonymous_ifr_ifru {
+            ifru_data: ptr::null_mut(),
+        },
+    }
+}
+
+pub(crate) struct TunImpl {
+    tun: Tun,
+}
+
+impl TunImpl {
+    #[inline]
+    pub fn new() -> io::Result<Self> {
+        Ok(Self { tun: Tun::new()? })
+    }
+
+    #[inline]
+    pub fn new_named(if_name: Interface) -> io::Result<Self> {
+        Ok(Self {
+            tun: Tun::new_named(if_name)?,
+        })
+    }
+
+    #[inline]
+    pub fn name(&self) -> io::Result<Interface> {
+        self.tun.name()
+    }
+
+    #[inline]
+    pub fn set_state(&mut self, state: DeviceState) -> io::Result<()> {
+        self.tun.set_state(state)
+    }
+
+    #[inline]
+    pub fn mtu(&self) -> io::Result<usize> {
+        self.tun.mtu()
+    }
+
+    #[inline]
+    pub fn set_nonblocking(&mut self, nonblocking: bool) -> io::Result<()> {
+        self.tun.set_nonblocking(nonblocking)
+    }
+
+    #[inline]
+    pub fn nonblocking(&self) -> io::Result<bool> {
+        self.tun.nonblocking()
+    }
+
+    #[inline]
+    pub fn send(&mut self, buf: &[u8]) -> io::Result<usize> {
+        self.tun.send(buf)
+    }
+
+    #[inline]
+    pub fn recv(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        self.tun.recv(buf)
+    }
+}
+
+pub(crate) struct TapImpl {
+    tap: Tap,
+}
+
+impl TapImpl {
+    #[inline]
+    pub fn new() -> io::Result<Self> {
+        Ok(Self { tap: Tap::new()? })
+    }
+
+    #[inline]
+    pub fn new_named(if_name: Interface) -> io::Result<Self> {
+        Ok(Self {
+            tap: Tap::new_named(if_name)?,
+        })
+    }
+
+    #[inline]
+    pub fn name(&self) -> io::Result<Interface> {
+        self.tap.name()
+    }
+
+    #[inline]
+    pub fn set_state(&mut self, state: DeviceState) -> io::Result<()> {
+        self.tap.set_state(state)
+    }
+
+    #[inline]
+    pub fn mtu(&self) -> io::Result<usize> {
+        self.tap.mtu()
+    }
+
+    #[inline]
+    pub fn set_nonblocking(&mut self, nonblocking: bool) -> io::Result<()> {
+        self.tap.set_nonblocking(nonblocking)
+    }
+
+    #[inline]
+    pub fn nonblocking(&self) -> io::Result<bool> {
+        self.tap.nonblocking()
+    }
+
+    #[inline]
+    pub fn send(&mut self, buf: &[u8]) -> io::Result<usize> {
+        self.tap.send(buf)
+    }
+
+    #[inline]
+    pub fn recv(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        self.tap.recv(buf)
+    }
+}

--- a/src/unix/tap.rs
+++ b/src/unix/tap.rs
@@ -1,0 +1,455 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+//
+// Copyright (c) 2024 Nathaniel Bennett <me[at]nathanielbennett[dotcom]>
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use std::os::fd::RawFd;
+use std::{array, io, ptr};
+
+use crate::{DeviceState, Interface};
+
+use super::ifreq_empty;
+use crate::libc_extra::*;
+
+pub struct Tap {
+    fd: RawFd,
+    persistent: bool,
+    // TODO: is there some way to fetch the interface name from a `/dev/tapX` fd? It appears not.
+    iface: Interface,
+}
+
+impl Tap {
+    /// Creates a new, unique TAP device.
+    #[inline]
+    pub fn new() -> io::Result<Self> {
+        Self::new_impl()
+    }
+
+    // NetBSD *does* have a `/dev/tap` cloned interface, but it makes only non-persistent TUN
+    // devices...
+    #[cfg(any(target_os = "openbsd", target_os = "netbsd"))]
+    #[inline]
+    fn new_impl() -> io::Result<Self> {
+        Self::new_from_loop()
+    }
+
+    #[cfg(target_os = "freebsd")]
+    #[inline]
+    fn new_impl() -> io::Result<Self> {
+        let mut buf = [0u8; 4];
+        let mut buflen = 4usize;
+
+        const DEVFS_CLONING: *const i8 = b"net.link.tap.devfs_cloning\0".as_ptr() as *const i8;
+
+        if unsafe {
+            libc::sysctlbyname(
+                DEVFS_CLONING,
+                buf.as_mut_ptr() as *mut libc::c_void,
+                ptr::addr_of_mut!(buflen),
+                ptr::null_mut(),
+                0,
+            )
+        } < 0
+        {
+            return Err(io::Error::last_os_error());
+        }
+
+        debug_assert_eq!(buflen, 4);
+        match &buf[..buflen] {
+            b"\x01\x00\x00\x00" => Self::new_from_cloned(), // TODO: endianness?
+            _ => Self::new_from_loop(),
+        }
+    }
+
+    #[cfg(target_os = "dragonfly")]
+    #[inline]
+    fn new_impl() -> io::Result<Self> {
+        Self::new_from_cloned()
+    }
+
+    #[cfg(any(target_os = "dragonfly", target_os = "freebsd"))]
+    fn new_from_cloned() -> io::Result<Self> {
+        let tap_ptr = b"/dev/tap\0".as_ptr() as *const i8;
+        // TODO: unify `ErrorKind`s returned
+        let fd = unsafe { libc::open(tap_ptr, libc::O_CREAT | libc::O_RDWR | libc::O_CLOEXEC) };
+        if fd < 0 {
+            return Err(io::Error::last_os_error());
+        }
+
+        let iface = match Self::tap_devname(fd) {
+            Ok(i) => i,
+            Err(e) => {
+                Self::close_fd(fd);
+                return Err(e);
+            }
+        };
+
+        Ok(Self {
+            fd,
+            persistent: false,
+            iface,
+        })
+    }
+
+    #[cfg(any(target_os = "dragonfly", target_os = "freebsd"))]
+    fn tap_devname(tap_fd: RawFd) -> io::Result<Interface> {
+        unsafe {
+            let mut name = [0u8; Interface::MAX_INTERFACE_NAME_LEN + 1];
+            if fdevname_r(
+                tap_fd,
+                name.as_mut_ptr() as *mut i8,
+                Interface::MAX_INTERFACE_NAME_LEN as i32,
+            )
+            .is_null()
+            {
+                return Err(io::Error::last_os_error());
+            }
+
+            Ok(Interface::from_raw(name))
+        }
+    }
+
+    /*
+    #[cfg(target_os = "netbsd")]
+    fn tap_devname(tap_fd: RawFd) -> io::Result<Interface> {
+        // NOTE: AIX does the same:
+        // https://www.ibm.com/docs/en/aix/7.2?topic=files-tap-special-file
+
+        const TAPGIFNAME: u64 = 0x40906500;
+
+        let mut req = ifreq_empty();
+
+        if unsafe { libc::ioctl(tap_fd, TAPGIFNAME, ptr::addr_of_mut!(req)) } < 0 {
+            return Err(io::Error::last_os_error())
+        }
+
+        Ok(unsafe { Interface::from_raw(array::from_fn(|i| req.ifr_name[i] as u8)) })
+    }
+    */
+
+    #[cfg(any(target_os = "freebsd", target_os = "netbsd", target_os = "openbsd"))]
+    fn new_from_loop() -> io::Result<Self> {
+        // Some BSD variants have no support for auto-selection of an unused TAP number, so we need
+        // to loop here.
+
+        for i in 3..1000 {
+            // Max TAP number is 999
+            match Self::new_numbered_impl(i, true) {
+                Err(e)
+                    if e.raw_os_error() == Some(libc::EBUSY)
+                        || e.raw_os_error() == Some(libc::EEXIST) =>
+                {
+                    continue
+                }
+                t => return t,
+            }
+        }
+
+        Err(io::Error::new(
+            io::ErrorKind::NotFound,
+            "no unused TAP number could be found for use",
+        ))
+    }
+
+    /// Opens or creates a TAP device of the given name.
+    #[inline]
+    pub fn new_named(iface: Interface) -> io::Result<Self> {
+        Self::new_named_impl(iface, false)
+    }
+
+    pub fn new_named_impl(iface: Interface, unique: bool) -> io::Result<Self> {
+        let tap_name = iface.name_raw();
+        if &tap_name[..3] != b"tap" {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "invalid name for TAP device (must begin with \"tap\")",
+            ));
+        }
+
+        let ctrl_fd = Self::ctrl_fd();
+
+        let mut req = ifreq_empty();
+        req.ifr_name = iface.name_raw_i8();
+
+        // FreeBSD returns ENXIO ("Device not configured") for SIOCIFCREATE and uses SIOCIFCREATE2
+        // instead within its `ifconfig` implementation. It passes no argument in the `ifr_ifru`
+        // field.
+        #[cfg(not(target_os = "freebsd"))]
+        const IOCTL_CREATE: u64 = SIOCIFCREATE;
+        #[cfg(target_os = "freebsd")]
+        const IOCTL_CREATE: u64 = SIOCIFCREATE2;
+
+        if unsafe { libc::ioctl(ctrl_fd, IOCTL_CREATE, ptr::addr_of_mut!(req)) } < 0 {
+            let err = io::Error::last_os_error();
+            if unique
+                || (err.raw_os_error() != Some(libc::EBUSY)
+                    && err.raw_os_error() != Some(libc::EEXIST))
+            {
+                Self::close_fd(ctrl_fd);
+                return Err(err);
+            }
+        }
+
+        let tap_path = [b"/dev/", iface.name_cstr().to_bytes_with_nul()].concat();
+        let tap_ptr = tap_path.as_ptr() as *const i8;
+
+        let fd = unsafe { libc::open(tap_ptr, libc::O_CREAT | libc::O_RDWR | libc::O_CLOEXEC) };
+        if fd < 0 {
+            let err = io::Error::last_os_error();
+            Self::destroy_iface(ctrl_fd, iface);
+            Self::close_fd(ctrl_fd);
+            return Err(err);
+        }
+
+        Self::close_fd(ctrl_fd);
+
+        Ok(Self {
+            fd,
+            persistent: false,
+            iface,
+        })
+    }
+
+    /// Opens or creates a TAP device of the given number.
+    #[inline]
+    pub fn new_numbered(tap_number: u32) -> io::Result<Self> {
+        Self::new_numbered_impl(tap_number, false)
+    }
+
+    #[inline]
+    fn new_numbered_impl(tap_number: u32, unique: bool) -> io::Result<Self> {
+        // "tap" + u32 + \0 won't overflow IFNAMSIZ
+        let tap_number = tap_number.to_string();
+        let tap_name = [b"tap", tap_number.as_bytes()].concat();
+
+        let iface = unsafe {
+            Interface::from_raw(array::from_fn(|i| {
+                if i < tap_name.len() {
+                    tap_name[i]
+                } else {
+                    0
+                }
+            }))
+        };
+        Self::new_named_impl(iface, unique)
+    }
+
+    /// Sets the persistence of the TAP interface.
+    ///
+    /// If set to `false`, the TAP device will be destroyed once all file descriptor handles to it
+    /// have been closed. If set to `true`, the TAP device will persist until it is explicitly
+    /// closed or the system reboots. By default, persistence is set to `true`.
+    #[inline]
+    pub fn set_persistent(&mut self, persistent: bool) -> io::Result<()> {
+        self.persistent = persistent;
+        Ok(())
+    }
+
+    /// Retrieves the interface name associated with the TAP device.
+    #[inline]
+    pub fn name(&self) -> io::Result<Interface> {
+        Ok(self.iface)
+    }
+
+    /// Retrieves the current state of the TAP device (i.e. "up" or "down").
+    #[inline]
+    pub fn state(&self) -> io::Result<DeviceState> {
+        let ctrl_fd = Self::ctrl_fd();
+
+        let mut req = ifreq_empty();
+        req.ifr_name = self.iface.name_raw_i8();
+
+        if unsafe { libc::ioctl(ctrl_fd, SIOCGIFFLAGS, ptr::addr_of_mut!(req)) } != 0 {
+            let err = io::Error::last_os_error();
+            Self::close_fd(ctrl_fd);
+            return Err(err);
+        }
+
+        #[cfg(any(target_os = "netbsd", target_os = "openbsd"))]
+        let is_up = unsafe { req.ifr_ifru.ifru_flags & libc::IFF_UP as i16 > 0 };
+        #[cfg(any(target_os = "dragonfly", target_os = "freebsd"))]
+        let is_up = unsafe { req.ifr_ifru.ifru_flags[0] & libc::IFF_UP as i16 > 0 };
+
+        Self::close_fd(ctrl_fd);
+
+        if is_up {
+            Ok(DeviceState::Up)
+        } else {
+            Ok(DeviceState::Down)
+        }
+    }
+
+    /// Sets the adapter state of the TAP device (e.g. "up" or "down").
+    #[inline]
+    pub fn set_state(&self, state: DeviceState) -> io::Result<()> {
+        let ctrl_fd = Self::ctrl_fd();
+
+        let mut req = ifreq_empty();
+        req.ifr_name = self.iface.name_raw_i8();
+
+        if unsafe { libc::ioctl(ctrl_fd, SIOCGIFFLAGS, ptr::addr_of_mut!(req)) } != 0 {
+            let err = io::Error::last_os_error();
+            Self::close_fd(ctrl_fd);
+            return Err(err);
+        }
+
+        unsafe {
+            match state {
+                #[cfg(any(target_os = "netbsd", target_os = "openbsd"))]
+                DeviceState::Down => req.ifr_ifru.ifru_flags &= !(libc::IFF_UP as i16),
+                #[cfg(any(target_os = "netbsd", target_os = "openbsd"))]
+                DeviceState::Up => req.ifr_ifru.ifru_flags |= libc::IFF_UP as i16,
+                #[cfg(any(target_os = "dragonfly", target_os = "freebsd"))]
+                DeviceState::Down => req.ifr_ifru.ifru_flags[0] &= !(libc::IFF_UP as i16),
+                #[cfg(any(target_os = "dragonfly", target_os = "freebsd"))]
+                DeviceState::Up => req.ifr_ifru.ifru_flags[0] |= libc::IFF_UP as i16,
+            }
+        }
+
+        if unsafe { libc::ioctl(ctrl_fd, SIOCSIFFLAGS, ptr::addr_of_mut!(req)) } != 0 {
+            let err = io::Error::last_os_error();
+            Self::close_fd(ctrl_fd);
+            return Err(err);
+        }
+
+        Self::close_fd(ctrl_fd);
+        Ok(())
+    }
+
+    /// Retrieves the Maximum Transmission Unit (MTU) of the TAP device.
+    #[inline]
+    pub fn mtu(&self) -> io::Result<usize> {
+        let mut req = ifreq_empty();
+        req.ifr_name = self.iface.name_raw_i8();
+
+        unsafe {
+            match libc::ioctl(self.fd, SIOCGIFMTU, ptr::addr_of_mut!(req)) {
+                0.. => {
+                    let mtu = req.ifr_ifru.ifru_mtu;
+                    if mtu < 0 {
+                        return Err(io::Error::new(
+                            io::ErrorKind::InvalidData,
+                            "unexpected negative MTU",
+                        ));
+                    }
+
+                    Ok(mtu as usize)
+                }
+                _ => Err(io::Error::last_os_error()),
+            }
+        }
+    }
+
+    /// Sets the Maximum Transmission Unit (MTU) of the TAP device.
+    #[inline]
+    pub fn set_mtu(&self, mtu: usize) -> io::Result<()> {
+        let Ok(mtu) = i32::try_from(mtu) else {
+            return Err(io::Error::new(io::ErrorKind::InvalidInput, "MTU too large"));
+        };
+
+        let mut req = ifreq_empty();
+        req.ifr_name = self.iface.name_raw_i8();
+        req.ifr_ifru.ifru_mtu = mtu;
+
+        unsafe {
+            match libc::ioctl(self.fd, SIOCSIFMTU, ptr::addr_of_mut!(req)) {
+                0.. => Ok(()),
+                _ => Err(io::Error::last_os_error()),
+            }
+        }
+    }
+
+    /// Reads a single packet from the TAP device.
+    #[inline]
+    pub fn recv(&self, buf: &mut [u8]) -> io::Result<usize> {
+        unsafe {
+            match libc::read(self.fd, buf.as_mut_ptr() as *mut libc::c_void, buf.len()) {
+                r @ 0.. => Ok(r as usize),
+                _ => Err(io::Error::last_os_error()),
+            }
+        }
+    }
+
+    /// Writes a single packet to the TAP device.
+    #[inline]
+    pub fn send(&self, buf: &[u8]) -> io::Result<usize> {
+        unsafe {
+            match libc::write(self.fd, buf.as_ptr() as *const libc::c_void, buf.len()) {
+                r @ 0.. => Ok(r as usize),
+                _ => Err(io::Error::last_os_error()),
+            }
+        }
+    }
+
+    /// Indicates whether nonblocking is enabled for `read` and `write` operations on the TAP device.
+    #[inline]
+    pub fn nonblocking(&self) -> io::Result<bool> {
+        let flags = unsafe { libc::fcntl(self.fd, libc::F_GETFL) };
+        if flags < 0 {
+            return Err(io::Error::last_os_error());
+        }
+
+        Ok(flags & libc::O_NONBLOCK > 0)
+    }
+
+    /// Sets nonblocking mode for `read` and `write` operations on the TAP device.
+    #[inline]
+    pub fn set_nonblocking(&self, nonblocking: bool) -> io::Result<()> {
+        let flags = unsafe { libc::fcntl(self.fd, libc::F_GETFL) };
+        if flags < 0 {
+            return Err(io::Error::last_os_error());
+        }
+
+        let flags = match nonblocking {
+            true => flags | libc::O_NONBLOCK,
+            false => flags & !libc::O_NONBLOCK,
+        };
+
+        if unsafe { libc::fcntl(self.fd, libc::F_SETFL, flags) } < 0 {
+            return Err(io::Error::last_os_error());
+        } else {
+            Ok(())
+        }
+    }
+
+    #[inline]
+    fn destroy_iface(fd: RawFd, iface: Interface) {
+        let mut req = ifreq_empty();
+        req.ifr_name = iface.name_raw_i8();
+
+        unsafe {
+            debug_assert_eq!(libc::ioctl(fd, SIOCIFDESTROY, ptr::addr_of_mut!(req)), 0);
+        }
+    }
+
+    #[inline]
+    fn ctrl_fd() -> RawFd {
+        let fd = unsafe { libc::socket(libc::AF_INET, libc::SOCK_DGRAM, 0) };
+
+        debug_assert!(fd >= 0);
+        fd
+    }
+
+    #[inline]
+    fn close_fd(fd: RawFd) {
+        unsafe {
+            debug_assert_eq!(libc::close(fd), 0);
+        }
+    }
+}
+
+impl Drop for Tap {
+    fn drop(&mut self) {
+        Self::close_fd(self.fd);
+        if !self.persistent {
+            let ctrl_fd = Self::ctrl_fd();
+            Self::destroy_iface(ctrl_fd, self.iface);
+            Self::close_fd(ctrl_fd);
+        }
+    }
+}

--- a/src/unix/tun.rs
+++ b/src/unix/tun.rs
@@ -1,0 +1,522 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+//
+// Copyright (c) 2024 Nathaniel Bennett <me[at]nathanielbennett[dotcom]>
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use std::os::fd::RawFd;
+use std::{array, io, ptr};
+
+use crate::{DeviceState, Interface};
+
+use super::ifreq_empty;
+use crate::libc_extra::*;
+
+// We use a custom `iovec` struct here because we don't want to do a *const to *mut conversion
+#[repr(C)]
+#[allow(non_camel_case_types)]
+pub struct iovec_const {
+    pub iov_base: *const libc::c_void,
+    pub iov_len: libc::size_t,
+}
+
+pub struct Tun {
+    fd: RawFd,
+    persistent: bool,
+    // TODO: is there some way to fetch the interface name from a `/dev/tunX` fd? It appears not.
+    iface: Interface,
+}
+
+impl Tun {
+    /// Creates a new, unique TUN device.
+    #[inline]
+    pub fn new() -> io::Result<Self> {
+        Self::new_impl()
+    }
+
+    #[cfg(any(target_os = "netbsd", target_os = "openbsd"))]
+    #[inline]
+    fn new_impl() -> io::Result<Self> {
+        Self::new_from_loop()
+    }
+
+    #[inline]
+    fn new_from_loop() -> io::Result<Self> {
+        // Some BSD variants have no support for auto-selection of an unused TUN number, so we need
+        // to loop here.
+
+        for i in 4..1000 {
+            // Max TUN number is 999
+            match Self::new_numbered_impl(i, true) {
+                Err(e)
+                    if e.raw_os_error() == Some(libc::EBUSY)
+                        || e.raw_os_error() == Some(libc::EEXIST) =>
+                {
+                    continue
+                }
+                t => return t,
+            }
+        }
+
+        Err(io::Error::new(
+            io::ErrorKind::NotFound,
+            "no unused TUN number could be found for use",
+        ))
+    }
+
+    #[cfg(target_os = "freebsd")]
+    #[inline]
+    fn new_impl() -> io::Result<Self> {
+        let mut buf = [0u8; 4];
+        let mut buflen = 4usize;
+
+        const DEVFS_CLONING: *const i8 = b"net.link.tun.devfs_cloning\0".as_ptr() as *const i8;
+
+        if unsafe {
+            libc::sysctlbyname(
+                DEVFS_CLONING,
+                buf.as_mut_ptr() as *mut libc::c_void,
+                ptr::addr_of_mut!(buflen),
+                ptr::null_mut(),
+                0,
+            )
+        } < 0
+        {
+            return Err(io::Error::last_os_error());
+        }
+
+        debug_assert_eq!(buflen, 4);
+        match &buf[..buflen] {
+            b"\x01\x00\x00\x00" => Self::new_from_cloned(),
+            _ => Self::new_from_loop(),
+        }
+    }
+
+    #[cfg(target_os = "dragonfly")]
+    #[inline]
+    fn new_impl() -> io::Result<Self> {
+        Self::new_from_cloned()
+    }
+
+    #[cfg(any(target_os = "dragonfly", target_os = "freebsd"))]
+    fn new_from_cloned() -> io::Result<Self> {
+        let tun_ptr = b"/dev/tun\0".as_ptr() as *const i8;
+        // TODO: unify `ErrorKind`s returned
+        let fd = unsafe { libc::open(tun_ptr, libc::O_CREAT | libc::O_RDWR | libc::O_CLOEXEC) };
+        if fd < 0 {
+            return Err(io::Error::last_os_error());
+        }
+
+        let iface = match Self::tun_devname(fd) {
+            Ok(i) => i,
+            Err(e) => {
+                Self::close_fd(fd);
+                return Err(e);
+            }
+        };
+
+        Ok(Self {
+            fd,
+            persistent: false,
+            iface,
+        })
+    }
+
+    #[cfg(any(target_os = "dragonfly", target_os = "freebsd"))]
+    fn tun_devname(tap_fd: RawFd) -> io::Result<Interface> {
+        unsafe {
+            let mut name = [0u8; Interface::MAX_INTERFACE_NAME_LEN + 1];
+            if fdevname_r(
+                tap_fd,
+                name.as_mut_ptr() as *mut i8,
+                Interface::MAX_INTERFACE_NAME_LEN as i32,
+            )
+            .is_null()
+            {
+                return Err(io::Error::last_os_error());
+            }
+
+            Ok(Interface::from_raw(name))
+        }
+    }
+
+    /// Opens or creates a TUN device of the given name.
+    pub fn new_named(iface: Interface) -> io::Result<Self> {
+        Self::new_named_impl(iface, false)
+    }
+
+    fn new_named_impl(iface: Interface, unique: bool) -> io::Result<Self> {
+        let tun_name = iface.name_raw();
+        if &tun_name[..3] != b"tun" {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "invalid name for TUN device (must begin with \"tun\")",
+            ));
+        }
+
+        let ctrl_fd = Self::ctrl_fd();
+
+        let mut req = ifreq_empty();
+        req.ifr_name = iface.name_raw_i8();
+
+        // FreeBSD returns ENXIO ("Device not configured") for SIOCIFCREATE and uses SIOCIFCREATE2
+        // instead within its `ifconfig` implementation. It passes no argument in the `ifr_ifru`
+        // field.
+        #[cfg(not(target_os = "freebsd"))]
+        const IOCTL_CREATE: u64 = SIOCIFCREATE;
+        #[cfg(target_os = "freebsd")]
+        const IOCTL_CREATE: u64 = SIOCIFCREATE2;
+
+        if unsafe { libc::ioctl(ctrl_fd, IOCTL_CREATE, ptr::addr_of_mut!(req)) } < 0 {
+            let err = io::Error::last_os_error();
+            if unique
+                || (err.raw_os_error() != Some(libc::EBUSY)
+                    && err.raw_os_error() != Some(libc::EEXIST))
+            {
+                Self::close_fd(ctrl_fd);
+                return Err(err);
+            }
+        }
+
+        let tun_path = [b"/dev/", iface.name_cstr().to_bytes_with_nul()].concat();
+        let tun_ptr = tun_path.as_ptr() as *const i8;
+
+        let fd = unsafe { libc::open(tun_ptr, libc::O_CREAT | libc::O_RDWR | libc::O_CLOEXEC) };
+        if fd < 0 {
+            let err = io::Error::last_os_error();
+            Self::destroy_iface(ctrl_fd, iface);
+            Self::close_fd(ctrl_fd);
+            return Err(err);
+        }
+
+        Self::close_fd(ctrl_fd);
+
+        Ok(Self {
+            fd,
+            persistent: false,
+            iface,
+        })
+    }
+
+    /// Opens or creates a TUN device of the given number.
+    #[inline]
+    pub fn new_numbered(tun_number: u32) -> io::Result<Self> {
+        Self::new_numbered_impl(tun_number, false)
+    }
+
+    #[inline]
+    fn new_numbered_impl(tun_number: u32, unique: bool) -> io::Result<Self> {
+        // "tap" + u32 + \0 won't overflow IFNAMSIZ
+        let tun_number = tun_number.to_string();
+        let tun_name = [b"tun", tun_number.as_bytes()].concat();
+
+        let iface = unsafe {
+            Interface::from_raw(array::from_fn(|i| {
+                if i < tun_name.len() {
+                    tun_name[i]
+                } else {
+                    0
+                }
+            }))
+        };
+        Self::new_named_impl(iface, unique)
+    }
+
+    /// Sets the persistence of the TUN interface.
+    ///
+    /// If set to `false`, the TUN device will be destroyed once all file descriptor handles to it
+    /// have been closed. If set to `true`, the TUN device will persist until it is explicitly
+    /// closed or the system reboots. By default, persistence is set to `true`.
+    #[inline]
+    pub fn set_persistent(&mut self, persistent: bool) -> io::Result<()> {
+        self.persistent = persistent;
+        Ok(())
+    }
+
+    /// Retrieves the interface name associated with the TUN device.
+    #[inline]
+    pub fn name(&self) -> io::Result<Interface> {
+        Ok(self.iface)
+    }
+
+    /// Retrieves the current state of the TUN device (i.e. "up" or "down").
+    #[inline]
+    pub fn state(&self) -> io::Result<DeviceState> {
+        let ctrl_fd = Self::ctrl_fd();
+
+        let mut req = ifreq_empty();
+        req.ifr_name = self.iface.name_raw_i8();
+
+        if unsafe { libc::ioctl(ctrl_fd, SIOCGIFFLAGS, ptr::addr_of_mut!(req)) } != 0 {
+            let err = io::Error::last_os_error();
+            Self::close_fd(ctrl_fd);
+            return Err(err);
+        }
+
+        #[cfg(any(target_os = "netbsd", target_os = "openbsd"))]
+        let flags = unsafe { req.ifr_ifru.ifru_flags };
+        #[cfg(any(target_os = "dragonfly", target_os = "freebsd"))]
+        let flags = unsafe { req.ifr_ifru.ifru_flags[0] };
+
+        Self::close_fd(ctrl_fd);
+
+        if flags & libc::IFF_UP as i16 > 0 {
+            Ok(DeviceState::Up)
+        } else {
+            Ok(DeviceState::Down)
+        }
+    }
+
+    /// Sets the adapter state of the TUN device (e.g. "up" or "down").
+    #[inline]
+    pub fn set_state(&self, state: DeviceState) -> io::Result<()> {
+        let ctrl_fd = Self::ctrl_fd();
+
+        let mut req = ifreq_empty();
+        req.ifr_name = self.iface.name_raw_i8();
+
+        if unsafe { libc::ioctl(ctrl_fd, SIOCGIFFLAGS, ptr::addr_of_mut!(req)) } != 0 {
+            let err = io::Error::last_os_error();
+            Self::close_fd(ctrl_fd);
+            return Err(err);
+        }
+
+        unsafe {
+            match state {
+                #[cfg(any(target_os = "netbsd", target_os = "openbsd"))]
+                DeviceState::Down => req.ifr_ifru.ifru_flags &= !(libc::IFF_UP as i16),
+                #[cfg(any(target_os = "netbsd", target_os = "openbsd"))]
+                DeviceState::Up => req.ifr_ifru.ifru_flags |= libc::IFF_UP as i16,
+                #[cfg(any(target_os = "dragonfly", target_os = "freebsd"))]
+                DeviceState::Down => req.ifr_ifru.ifru_flags[0] &= !(libc::IFF_UP as i16),
+                #[cfg(any(target_os = "dragonfly", target_os = "freebsd"))]
+                DeviceState::Up => req.ifr_ifru.ifru_flags[0] |= libc::IFF_UP as i16,
+            }
+        }
+
+        if unsafe { libc::ioctl(ctrl_fd, SIOCSIFFLAGS, ptr::addr_of_mut!(req)) } != 0 {
+            let err = io::Error::last_os_error();
+            Self::close_fd(ctrl_fd);
+            return Err(err);
+        }
+
+        Self::close_fd(ctrl_fd);
+        Ok(())
+    }
+
+    /// Retrieves the Maximum Transmission Unit (MTU) of the TUN device.
+    #[inline]
+    pub fn mtu(&self) -> io::Result<usize> {
+        let mut req = ifreq_empty();
+        req.ifr_name = self.name()?.name_raw_i8();
+
+        unsafe {
+            match libc::ioctl(self.fd, SIOCGIFMTU, ptr::addr_of_mut!(req)) {
+                0.. => {
+                    let mtu = req.ifr_ifru.ifru_mtu;
+                    if mtu < 0 {
+                        return Err(io::Error::new(
+                            io::ErrorKind::InvalidData,
+                            "unexpected negative MTU",
+                        ));
+                    }
+
+                    Ok(mtu as usize)
+                }
+                _ => Err(io::Error::last_os_error()),
+            }
+        }
+    }
+
+    /// Sets the Maximum Transmission Unit (MTU) of the TUN device.
+    #[inline]
+    pub fn set_mtu(&self, mtu: usize) -> io::Result<()> {
+        let Ok(mtu) = i32::try_from(mtu) else {
+            return Err(io::Error::new(io::ErrorKind::InvalidInput, "MTU too large"));
+        };
+
+        let mut req = ifreq_empty();
+        req.ifr_name = self.name()?.name_raw_i8();
+        req.ifr_ifru.ifru_mtu = mtu;
+
+        unsafe {
+            match libc::ioctl(self.fd, SIOCSIFMTU, ptr::addr_of_mut!(req)) {
+                0.. => Ok(()),
+                _ => Err(io::Error::last_os_error()),
+            }
+        }
+    }
+
+    /// Reads a single packet from the TUN device.
+    #[inline]
+    pub fn recv(&self, buf: &mut [u8]) -> io::Result<usize> {
+        self.recv_impl(buf)
+    }
+
+    #[cfg(any(target_os = "dragonfly", target_os = "freebsd"))]
+    #[inline]
+    pub fn recv_impl(&self, buf: &mut [u8]) -> io::Result<usize> {
+        unsafe {
+            match libc::read(self.fd, buf.as_mut_ptr() as *mut libc::c_void, buf.len()) {
+                r @ 0.. => Ok(r as usize),
+                _ => Err(io::Error::last_os_error()),
+            }
+        }
+    }
+
+    #[cfg(any(target_os = "netbsd", target_os = "openbsd"))]
+    #[inline]
+    pub fn recv_impl(&self, buf: &mut [u8]) -> io::Result<usize> {
+        let mut family_prefix = [0u8; 4];
+        let mut iov = [
+            libc::iovec {
+                iov_base: family_prefix.as_mut_ptr() as *mut libc::c_void,
+                iov_len: family_prefix.len(),
+            },
+            libc::iovec {
+                iov_base: buf.as_mut_ptr() as *mut libc::c_void,
+                iov_len: buf.len(),
+            },
+        ];
+
+        unsafe {
+            match libc::readv(self.fd, iov.as_mut_ptr(), 2) {
+                0..=3 => Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "insufficient bytes received from utun to form packet",
+                )),
+                r @ 4.. => Ok((r - 4) as usize),
+                _ => Err(io::Error::last_os_error()),
+            }
+        }
+    }
+
+    /// Writes a single packet to the TUN device.
+    #[inline]
+    pub fn send(&self, buf: &[u8]) -> io::Result<usize> {
+        self.send_impl(buf)
+    }
+
+    #[cfg(any(target_os = "dragonfly", target_os = "freebsd"))]
+    #[inline]
+    pub fn send_impl(&self, buf: &[u8]) -> io::Result<usize> {
+        unsafe {
+            match libc::write(self.fd, buf.as_ptr() as *const libc::c_void, buf.len()) {
+                r @ 0.. => Ok(r as usize),
+                _ => Err(io::Error::last_os_error()),
+            }
+        }
+    }
+
+    #[cfg(any(target_os = "netbsd", target_os = "openbsd"))]
+    #[inline]
+    pub fn send_impl(&self, buf: &[u8]) -> io::Result<usize> {
+        if buf.len() == 0 {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "packet must not be empty",
+            ));
+        }
+
+        let family_prefix = match buf[0] & 0x0f {
+            0x04 => [0u8, 0, 0, 2],
+            0x06 => [0u8, 0, 0, 10],
+            _ => {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidInput,
+                    "only IPv4 and IPv6 packets are supported over tun",
+                ))
+            }
+        };
+
+        let iov = [
+            iovec_const {
+                iov_base: family_prefix.as_ptr() as *const libc::c_void,
+                iov_len: family_prefix.len(),
+            },
+            iovec_const {
+                iov_base: buf.as_ptr() as *const libc::c_void,
+                iov_len: buf.len(),
+            },
+        ];
+
+        unsafe {
+            match libc::writev(self.fd, iov.as_ptr() as *const libc::iovec, 2) {
+                r @ 0.. => Ok((r as usize).saturating_sub(family_prefix.len())),
+                _ => Err(io::Error::last_os_error()),
+            }
+        }
+    }
+
+    /// Indicates whether nonblocking is enabled for `read` and `write` operations on the TUN device.
+    #[inline]
+    pub fn nonblocking(&self) -> io::Result<bool> {
+        let flags = unsafe { libc::fcntl(self.fd, libc::F_GETFL) };
+        if flags < 0 {
+            return Err(io::Error::last_os_error());
+        }
+
+        Ok(flags & libc::O_NONBLOCK > 0)
+    }
+
+    /// Sets nonblocking mode for `read` and `write` operations on the TUN device.
+    #[inline]
+    pub fn set_nonblocking(&self, nonblocking: bool) -> io::Result<()> {
+        let flags = unsafe { libc::fcntl(self.fd, libc::F_GETFL) };
+        if flags < 0 {
+            return Err(io::Error::last_os_error());
+        }
+
+        let flags = match nonblocking {
+            true => flags | libc::O_NONBLOCK,
+            false => flags & !libc::O_NONBLOCK,
+        };
+
+        if unsafe { libc::fcntl(self.fd, libc::F_SETFL, flags) } < 0 {
+            return Err(io::Error::last_os_error());
+        } else {
+            Ok(())
+        }
+    }
+
+    #[inline]
+    fn ctrl_fd() -> RawFd {
+        let fd = unsafe { libc::socket(libc::AF_INET, libc::SOCK_DGRAM, 0) };
+
+        debug_assert!(fd >= 0);
+        fd
+    }
+
+    #[inline]
+    fn close_fd(fd: RawFd) {
+        unsafe {
+            debug_assert_eq!(libc::close(fd), 0);
+        }
+    }
+
+    #[inline]
+    fn destroy_iface(fd: RawFd, iface: Interface) {
+        let mut req = ifreq_empty();
+        req.ifr_name = iface.name_raw_i8();
+
+        unsafe {
+            debug_assert_eq!(libc::ioctl(fd, SIOCIFDESTROY, ptr::addr_of_mut!(req)), 0);
+        }
+    }
+}
+
+impl Drop for Tun {
+    fn drop(&mut self) {
+        Self::close_fd(self.fd);
+
+        if !self.persistent {
+            let ctrl_fd = Self::ctrl_fd();
+            Self::destroy_iface(ctrl_fd, self.iface);
+            Self::close_fd(ctrl_fd);
+        }
+    }
+}


### PR DESCRIPTION
Adds basic TUN/TAP types and cross-platform support for DragonFly BSD, FreeBSD, NetBSD and OpenBSD.

NOTE: CI needs to be implemented for these platforms, and while Solaris/IllumOS *should* implement the same interfaces I don't have any indication that they are working properly yet.