### PR TITLE
Add async Tun/Tap implementations

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,8 +1,11 @@
+# Needed to avoid race conditions when testing TUN/TAP interfaces on machine
+[env]
+RUST_TEST_THREADS = "1"
+
+# TUN/TAP interfaces require admin privileges to test
 [target.'cfg(unix)']
 runner = 'sudo -E'
 
+# TUN/TAP interfaces require admin privileges to test
 [target.'cfg(windows)']
 runner = "powershell -Command Start-Process -Verb runAs -FilePath"
-
-[env]
-RUST_TEST_THREADS = "1"

--- a/.github/workflows/full_ci.yml
+++ b/.github/workflows/full_ci.yml
@@ -29,7 +29,7 @@ jobs:
       matrix:
         toolchain:
           - stable
-          - 1.66.0
+          - 1.70.0
     steps:
       - uses: actions/checkout@v4
       - name: Setup Rust toolchain
@@ -47,7 +47,7 @@ jobs:
       matrix:
         target:
           - { toolchain: stable, os: macos-14 }
-          - { toolchain: 1.66.0, os: macos-14 }
+          - { toolchain: 1.70.0, os: macos-14 }
     runs-on: ${{ matrix.target.os }}
     steps:
       - uses: actions/checkout@v4
@@ -66,7 +66,7 @@ jobs:
       matrix:
         toolchain:
           - stable
-          - 1.66.0
+          - 1.70.0
         target:
           - x86_64-pc-windows-msvc
     steps:
@@ -142,7 +142,7 @@ jobs:
       matrix:
         toolchain:
           - stable
-          - 1.66.0
+          - 1.70.0
     steps:
     - uses: actions/checkout@v4
     - name: Test in FreeBSD
@@ -171,7 +171,7 @@ jobs:
       matrix:
         toolchain:
           - stable
-          - 1.66.0
+          - 1.70.0
     steps:
     - uses: actions/checkout@v4
     - name: Test in NetBSD
@@ -211,7 +211,7 @@ jobs:
 #      matrix:
 #        toolchain:
 #          - stable
-#          - 1.66.0
+#          - 1.70.0
 #    steps:
 #    - uses: actions/checkout@v4
 #    - name: Test in OpenBSD

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,8 +3,8 @@ name = "tappers"
 authors = ["Nathaniel Bennett <me[at]nathanielbennett[dotcom]>"]
 description = "Cross-platform TUN, TAP and vETH interfaces"
 # 1.66 - `std::os::fd` stabilized
-rust-version = "1.66" 
-version = "0.3.1"
+rust-version = "1.70" 
+version = "0.4.0"
 license = "MIT OR Apache-2.0"
 edition = "2021"
 repository = "https://github.com/pkts-rs/tappers"
@@ -25,8 +25,14 @@ tapwin6 = []
 wintun-runtime = ["wintun"]
 # Enables fallible run-time loading of tap-windows6 (default is load-time)
 tapwin6-runtime = ["tapwin6"]
+mio = ["dep:mio"]
+tokio = ["dep:tokio"]
+async-io = ["dep:async-io"]
 
 [dependencies]
 libc = { version = "0.2" }
 windows-sys = { version = "0.59", features = ["Win32", "Win32_NetworkManagement", "Win32_NetworkManagement_IpHelper", "Win32_NetworkManagement_Ndis", "Win32_System", "Win32_System_LibraryLoader", "Win32_System_Threading"] }
 once_cell = { version = "1.19" }
+mio = { version = "0.8.11", features = ["net"], optional = true }
+tokio = { version = "1.38.1", features = ["net", "time"], optional = true }
+async-io = { version = "2.3.4", optional = true }

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ tap.set_state(DeviceState::Down);
 | TUN/TAP support for *BSD                    | ✅        | ⬜             | FreeBSD/TUN only | ⬜         | OpenBSD   | ⬜          |
 | TUN/TAP support for Solaris/IllumOS         | ⬜        | ⬜             | ⬜               | ⬜         | ⬜        | ⬜          |
 | non-`async` support                         | ✅        | ✅             | ✅               | ✅         | ✅        | ⬜          |
-| `async` support                             | Planned   | ✅             | Unix only        | ✅         | ⬜        | ✅          |
+| `async` support                             | ✅        | ✅             | Unix only        | ✅         | ⬜        | ✅          |
 
 `*` - `tappers` doesn't currently support setting or deleting IP addresses in Windows. This because
 Windows fundamentally lacks support for adding or changing IPv6 interface addresses in current APIs.
@@ -222,15 +222,14 @@ All `Tun` and `Tap` types implement synchronous blocking/nonblocking `send()` an
 In addition to this, `tappers` will aim to provide first-class support for the following `async`
 runtimes:
 
-| `async` Runtime | Supported?    |
-| --------------- | ------------- |
-| `mio`           | ⬜            |
-| `tokio`         | ⬜            |
-| `futures`       | ⬜            |
-| `async-std`     | Via `futures` |
-| `smol`          | Via `futures` |
+| `async` Runtime | Supported?          |
+| --------------- | ------------------- |
+| `mio`           | ✅*                 |
+| `tokio`         | ✅                  |
+| `async-std`     | ✅ (via `async-io`) |
+| `smol`          | ✅ (via `async-io`) |
 
-Note that this library is currently a work in progress--`async` runtimes will soon be supported.
+`*` - on all platforms except for Windows
 
 ## Dependency Policy
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,10 @@
 # Release History:
 
+* 0.4.0
+  - Change `send()`, `recv()` functions to be immutable
+  - Add async implementations for `async-std`, `mio`, `smol`, `tokio`
+  - Move Rust MSRV up to 1.70 (to support `mio`)
+
 * 0.3.1
   - Make docs show platform-specific APIS
   - Update documentation

--- a/ci/run.sh
+++ b/ci/run.sh
@@ -37,17 +37,35 @@ esac
 
 case "${OS}" in
     windows*)
-        cargo test --features wintun
+        cargo test --all-targets
 
-        cargo test --features wintun-runtime
+        cargo test --all-targets --features wintun
 
-        cargo test --features tapwin6
+        cargo test --all-targets --features wintun-runtime
 
-        cargo test --features tapwin6-runtime
+        cargo test --all-targets --features tapwin6
+
+        cargo test --all-targets --features tapwin6-runtime
+
+        cargo test --all-targets --all-features
+
+        # doc tests must have all features enabled to run
+        cargo test --doc --all-features
         ;;
     *)
         # No extra features in any platform other than windows
 
-        cargo test
+        cargo test --all-targets
+
+        cargo test --all-targets --features async-io
+
+        cargo test --all-targets --features mio
+
+        cargo test --all-targets --features tokio
+
+        cargo test --all-targets --all-features
+
+        # doc tests must have all features enabled to run
+        cargo test --doc --all-features
         ;;
 esac

--- a/src/async_io.rs
+++ b/src/async_io.rs
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+//
+// Copyright (c) 2024 Nathaniel Bennett <me[at]nathanielbennett[dotcom]>
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+//! Async `Tun`/`Tap` interfaces compatible with `async-std` and/or `smol`.
+
+#[cfg(not(target_os = "windows"))]
+mod tap;
+mod tun;
+
+#[cfg(not(target_os = "windows"))]
+pub use tap::AsyncTap;
+pub use tun::AsyncTun;

--- a/src/async_io/tap.rs
+++ b/src/async_io/tap.rs
@@ -1,0 +1,262 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+//
+// Copyright (c) 2024 Nathaniel Bennett <me[at]nathanielbennett[dotcom]>
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use std::io;
+#[cfg(target_os = "windows")]
+use std::mem::ManuallyDrop;
+#[cfg(not(target_os = "windows"))]
+use std::net::IpAddr;
+#[cfg(target_os = "windows")]
+use std::os::windows::io::{AsSocket, BorrowedSocket, RawSocket};
+#[cfg(target_os = "windows")]
+use std::time::Duration;
+
+#[cfg(not(target_os = "windows"))]
+use crate::{AddAddress, AddressInfo};
+use crate::{DeviceState, Interface, Tap};
+
+#[cfg(not(target_os = "windows"))]
+use async_io::Async;
+#[cfg(target_os = "windows")]
+use async_io::Timer;
+
+#[cfg(target_os = "windows")]
+struct TapWrapper(Tap);
+
+#[cfg(target_os = "windows")]
+impl TapWrapper {
+    #[inline]
+    pub fn name(&self) -> io::Result<Interface> {
+        self.0.name()
+    }
+
+    #[inline]
+    pub fn set_state(&mut self, state: DeviceState) -> io::Result<()> {
+        self.0.set_state(state)
+    }
+
+    #[inline]
+    pub fn set_up(&mut self) -> io::Result<()> {
+        self.0.set_up()
+    }
+
+    #[inline]
+    pub fn set_down(&mut self) -> io::Result<()> {
+        self.0.set_down()
+    }
+
+    #[inline]
+    pub fn mtu(&self) -> io::Result<usize> {
+        self.0.mtu()
+    }
+
+    #[cfg(not(target_os = "windows"))]
+    #[inline]
+    pub fn addrs(&self) -> io::Result<Vec<AddressInfo>> {
+        self.0.addrs()
+    }
+
+    #[cfg(not(target_os = "windows"))]
+    #[inline]
+    pub fn add_addr<A: Into<AddAddress>>(&self, req: A) -> io::Result<()> {
+        self.0.add_addr(req)
+    }
+
+    #[cfg(not(target_os = "windows"))]
+    #[inline]
+    pub fn remove_addr(&self, addr: IpAddr) -> io::Result<()> {
+        self.0.remove_addr(addr)
+    }
+}
+
+#[cfg(target_os = "windows")]
+impl AsSocket for TapWrapper {
+    fn as_socket(&self) -> BorrowedSocket<'_> {
+        unsafe { BorrowedSocket::borrow_raw(self.inner.read_handle() as RawSocket) }
+    }
+}
+
+/// A cross-platform asynchronous TAP interface, suitable for tunnelling link-layer packets.
+pub struct AsyncTap {
+    tap: Async<Tap>,
+    #[cfg(target_os = "windows")]
+    tap: Async<TapWrapper>,
+}
+
+impl AsyncTap {
+    /// Creates a new, unique TAP device.
+    #[inline]
+    pub fn new() -> io::Result<Self> {
+        Self::new_impl()
+    }
+
+    #[cfg(target_os = "windows")]
+    fn new_impl() -> io::Result<Self> {
+        let mut tap = Tap::new()?;
+        tap.set_nonblocking(true)?;
+
+        Ok(Self {
+            tap: Async::new(TapWrapper(tap)),
+        })
+    }
+
+    #[cfg(not(target_os = "windows"))]
+    fn new_impl() -> io::Result<Self> {
+        let mut tap = Tap::new()?;
+        tap.set_nonblocking(true)?;
+
+        Ok(Self {
+            tap: Async::new(tap)?,
+        })
+    }
+
+    /// Opens or creates a TAP device of the given name.
+    #[inline]
+    pub fn new_named(if_name: Interface) -> io::Result<Self> {
+        Self::new_named_impl(if_name)
+    }
+
+    #[cfg(not(target_os = "windows"))]
+    pub fn new_named_impl(if_name: Interface) -> io::Result<Self> {
+        let mut tap = Tap::new_named(if_name)?;
+        tap.set_nonblocking(true)?;
+
+        Ok(Self {
+            tap: Async::new(tap)?,
+        })
+    }
+
+    #[cfg(target_os = "windows")]
+    pub fn new_named_impl(if_name: Interface) -> io::Result<Self> {
+        let mut tap = Tap::new_named(if_name)?;
+        tap.set_nonblocking(true)?;
+
+        Ok(Self {
+            tap: Async::new(TapWrapper(tap))?,
+        })
+    }
+
+    /// Retrieves the interface name of the TAP device.
+    #[inline]
+    pub fn name(&self) -> io::Result<Interface> {
+        self.tap.get_ref().name()
+    }
+
+    /// Sets the adapter state of the TAP device (e.g. "up" or "down").
+    #[inline]
+    pub fn set_state(&mut self, state: DeviceState) -> io::Result<()> {
+        unsafe { self.tap.get_mut().set_state(state) }
+    }
+
+    /// Sets the adapter state of the TAP device to "up".
+    #[inline]
+    pub fn set_up(&mut self) -> io::Result<()> {
+        unsafe { self.tap.get_mut().set_state(DeviceState::Up) }
+    }
+
+    /// Sets the adapter state of the TAP device to "down".
+    #[inline]
+    pub fn set_down(&mut self) -> io::Result<()> {
+        unsafe { self.tap.get_mut().set_state(DeviceState::Down) }
+    }
+
+    /// Retrieves the Maximum Transmission Unit (MTU) of the TAP device.
+    #[inline]
+    pub fn mtu(&self) -> io::Result<usize> {
+        self.tap.get_ref().mtu()
+    }
+
+    /// Retrieves the network-layer addresses assigned to the interface.
+    ///
+    /// Most platforms automatically assign a link-local IPv6 address to TAP devices on creation.
+    /// Developers should take this into account and avoid the incorrect assumption that `addrs()`
+    /// will return only the addresses they have assigned via [`add_addr()`](Self::add_addr).
+    /// [`add_addr()`](Self::add_addr).
+    #[cfg(not(target_os = "windows"))]
+    #[inline]
+    pub fn addrs(&self) -> io::Result<Vec<AddressInfo>> {
+        self.tap.get_ref().addrs()
+    }
+
+    // TODO: this used to be the case, but now it's not??
+    //    /// MacOS additionally requires a destination address when assigning an IPv6 address to a TAP
+    //    /// device. Neither FreeBSD nor DragonFlyBSD include this restriction.
+
+    /// Assigns a network-layer address to the interface.
+    #[cfg(not(target_os = "windows"))]
+    #[inline]
+    pub fn add_addr<A: Into<AddAddress>>(&self, req: A) -> io::Result<()> {
+        self.tap.get_ref().add_addr(req)
+    }
+
+    /// Removes the specified network-layer address from the interface.
+    #[cfg(not(target_os = "windows"))]
+    #[inline]
+    pub fn remove_addr(&self, addr: IpAddr) -> io::Result<()> {
+        self.tap.get_ref().remove_addr(addr)
+    }
+
+    /// Sends a packet over the TAP device.
+    #[inline]
+    pub async fn send(&self, buf: &[u8]) -> io::Result<usize> {
+        self.send_impl(buf).await
+    }
+
+    #[cfg(not(target_os = "windows"))]
+    #[inline]
+    async fn send_impl(&self, buf: &[u8]) -> io::Result<usize> {
+        self.tap.write_with(|inner| inner.send(buf)).await
+    }
+
+    #[cfg(target_os = "windows")]
+    #[inline]
+    async fn send_impl(&self, buf: &[u8]) -> io::Result<usize> {
+        const SEND_MAX_BLOCKING_INTERVAL: u64 = 100;
+        let mut timeout = 1; // Start with 1 millisecond timeout
+
+        loop {
+            match self.tap.as_ref().0.send(buf) {
+                Err(e) if e.kind() == io::ErrorKind::WouldBlock => {
+                    Timer::after(Duration::from_millis(timeout)).await;
+                    timeout = cmp::min(timeout * 2, SEND_MAX_BLOCKING_INTERVAL);
+                }
+                res => return res,
+            }
+        }
+    }
+
+    /// Receives a packet over the TAP device.
+    #[inline]
+    pub async fn recv(&self, buf: &mut [u8]) -> io::Result<usize> {
+        self.recv_impl(buf).await
+    }
+
+    #[cfg(not(target_os = "windows"))]
+    pub async fn recv_impl(&self, buf: &mut [u8]) -> io::Result<usize> {
+        self.tap.read_with(|inner| inner.recv(buf)).await
+    }
+
+    #[cfg(target_os = "windows")]
+    pub async fn recv_impl(&self, buf: &mut [u8]) -> io::Result<usize> {
+        self.tap.read_with(|inner| inner.0.recv(buf)).await
+    }
+}
+
+impl Drop for AsyncTap {
+    fn drop(&mut self) {
+        #[cfg(target_os = "windows")]
+        {
+            // This ensures that `UdpSocket` is dropped properly while not double-closing the RawFd.
+            // SAFETY: `self.io` won't be accessed after this thanks to ManuallyDrop
+            let io = unsafe { ManuallyDrop::take(&mut self.io) };
+            io.into_raw_fd();
+        }
+    }
+}

--- a/src/async_io/tun.rs
+++ b/src/async_io/tun.rs
@@ -1,0 +1,261 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+//
+// Copyright (c) 2024 Nathaniel Bennett <me[at]nathanielbennett[dotcom]>
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use std::io;
+#[cfg(target_os = "windows")]
+use std::mem::ManuallyDrop;
+#[cfg(not(target_os = "windows"))]
+use std::net::IpAddr;
+#[cfg(target_os = "windows")]
+use std::os::windows::io::{AsSocket, BorrowedSocket, RawSocket};
+#[cfg(target_os = "windows")]
+use std::time::Duration;
+
+#[cfg(not(target_os = "windows"))]
+use crate::{AddAddress, AddressInfo};
+use crate::{DeviceState, Interface, Tun};
+
+use async_io::Async;
+#[cfg(target_os = "windows")]
+use async_io::Timer;
+
+#[cfg(target_os = "windows")]
+struct TunWrapper(Tun);
+
+#[cfg(target_os = "windows")]
+impl TunWrapper {
+    #[inline]
+    pub fn name(&self) -> io::Result<Interface> {
+        self.0.name()
+    }
+
+    #[inline]
+    pub fn set_state(&mut self, state: DeviceState) -> io::Result<()> {
+        self.0.set_state(state)
+    }
+
+    #[inline]
+    pub fn set_up(&mut self) -> io::Result<()> {
+        self.0.set_up()
+    }
+
+    #[inline]
+    pub fn set_down(&mut self) -> io::Result<()> {
+        self.0.set_down()
+    }
+
+    #[inline]
+    pub fn mtu(&self) -> io::Result<usize> {
+        self.0.mtu()
+    }
+
+    #[cfg(not(target_os = "windows"))]
+    #[inline]
+    pub fn addrs(&self) -> io::Result<Vec<AddressInfo>> {
+        self.0.addrs()
+    }
+
+    #[cfg(not(target_os = "windows"))]
+    #[inline]
+    pub fn add_addr<A: Into<AddAddress>>(&self, req: A) -> io::Result<()> {
+        self.0.add_addr(req)
+    }
+
+    #[cfg(not(target_os = "windows"))]
+    #[inline]
+    pub fn remove_addr(&self, addr: IpAddr) -> io::Result<()> {
+        self.0.remove_addr(addr)
+    }
+}
+
+#[cfg(target_os = "windows")]
+impl AsSocket for TunWrapper {
+    fn as_socket(&self) -> BorrowedSocket<'_> {
+        unsafe { BorrowedSocket::borrow_raw(self.inner.read_handle() as RawSocket) }
+    }
+}
+
+/// A cross-platform asynchronous TUN interface, suitable for tunnelling network-layer packets.
+pub struct AsyncTun {
+    tun: Async<Tun>,
+    #[cfg(target_os = "windows")]
+    tun: Async<TunWrapper>,
+}
+
+impl AsyncTun {
+    /// Creates a new, unique TUN device.
+    #[inline]
+    pub fn new() -> io::Result<Self> {
+        Self::new_impl()
+    }
+
+    #[cfg(target_os = "windows")]
+    fn new_impl() -> io::Result<Self> {
+        let mut tun = Tun::new()?;
+        tun.set_nonblocking(true)?;
+
+        Ok(Self {
+            tun: Async::new(TunWrapper(tun)),
+        })
+    }
+
+    #[cfg(not(target_os = "windows"))]
+    fn new_impl() -> io::Result<Self> {
+        let mut tun = Tun::new()?;
+        tun.set_nonblocking(true)?;
+
+        Ok(Self {
+            tun: Async::new(tun)?,
+        })
+    }
+
+    /// Opens or creates a TUN device of the given name.
+    #[inline]
+    pub fn new_named(if_name: Interface) -> io::Result<Self> {
+        Self::new_named_impl(if_name)
+    }
+
+    #[cfg(not(target_os = "windows"))]
+    pub fn new_named_impl(if_name: Interface) -> io::Result<Self> {
+        let mut tun = Tun::new_named(if_name)?;
+        tun.set_nonblocking(true)?;
+
+        Ok(Self {
+            tun: Async::new(tun)?,
+        })
+    }
+
+    #[cfg(target_os = "windows")]
+    pub fn new_named_impl(if_name: Interface) -> io::Result<Self> {
+        let mut tun = Tun::new_named(if_name)?;
+        tun.set_nonblocking(true)?;
+
+        Ok(Self {
+            tun: Async::new(TunWrapper(tun))?,
+        })
+    }
+
+    /// Retrieves the interface name of the TUN device.
+    #[inline]
+    pub fn name(&self) -> io::Result<Interface> {
+        self.tun.get_ref().name()
+    }
+
+    /// Sets the adapter state of the TUN device (e.g. "up" or "down").
+    #[inline]
+    pub fn set_state(&mut self, state: DeviceState) -> io::Result<()> {
+        unsafe { self.tun.get_mut().set_state(state) }
+    }
+
+    /// Sets the adapter state of the TUN device to "up".
+    #[inline]
+    pub fn set_up(&mut self) -> io::Result<()> {
+        unsafe { self.tun.get_mut().set_state(DeviceState::Up) }
+    }
+
+    /// Sets the adapter state of the TUN device to "down".
+    #[inline]
+    pub fn set_down(&mut self) -> io::Result<()> {
+        unsafe { self.tun.get_mut().set_state(DeviceState::Down) }
+    }
+
+    /// Retrieves the Maximum Transmission Unit (MTU) of the TUN device.
+    #[inline]
+    pub fn mtu(&self) -> io::Result<usize> {
+        self.tun.get_ref().mtu()
+    }
+
+    /// Retrieves the network-layer addresses assigned to the interface.
+    ///
+    /// Most platforms automatically assign a link-local IPv6 address to TUN devices on creation.
+    /// Developers should take this into account and avoid the incorrect assumption that `addrs()`
+    /// will return only the addresses they have assigned via [`add_addr()`](Self::add_addr).
+    /// [`add_addr()`](Self::add_addr).
+    #[cfg(not(target_os = "windows"))]
+    #[inline]
+    pub fn addrs(&self) -> io::Result<Vec<AddressInfo>> {
+        self.tun.get_ref().addrs()
+    }
+
+    // TODO: this used to be the case, but now it's not??
+    //    /// MacOS additionally requires a destination address when assigning an IPv6 address to a TUN
+    //    /// device. Neither FreeBSD nor DragonFlyBSD include this restriction.
+
+    /// Assigns a network-layer address to the interface.
+    #[cfg(not(target_os = "windows"))]
+    #[inline]
+    pub fn add_addr<A: Into<AddAddress>>(&self, req: A) -> io::Result<()> {
+        self.tun.get_ref().add_addr(req)
+    }
+
+    /// Removes the specified network-layer address from the interface.
+    #[cfg(not(target_os = "windows"))]
+    #[inline]
+    pub fn remove_addr(&self, addr: IpAddr) -> io::Result<()> {
+        self.tun.get_ref().remove_addr(addr)
+    }
+
+    /// Sends a packet over the TUN device.
+    #[inline]
+    pub async fn send(&self, buf: &[u8]) -> io::Result<usize> {
+        self.send_impl(buf).await
+    }
+
+    #[cfg(not(target_os = "windows"))]
+    #[inline]
+    async fn send_impl(&self, buf: &[u8]) -> io::Result<usize> {
+        self.tun.write_with(|inner| inner.send(buf)).await
+    }
+
+    #[cfg(target_os = "windows")]
+    #[inline]
+    async fn send_impl(&self, buf: &[u8]) -> io::Result<usize> {
+        const SEND_MAX_BLOCKING_INTERVAL: u64 = 100;
+        let mut timeout = 1; // Start with 1 millisecond timeout
+
+        loop {
+            match self.tun.as_ref().0.send(buf) {
+                Err(e) if e.kind() == io::ErrorKind::WouldBlock => {
+                    Timer::after(Duration::from_millis(timeout)).await;
+                    timeout = cmp::min(timeout * 2, SEND_MAX_BLOCKING_INTERVAL);
+                }
+                res => return res,
+            }
+        }
+    }
+
+    /// Receives a packet over the TUN device.
+    #[inline]
+    pub async fn recv(&self, buf: &mut [u8]) -> io::Result<usize> {
+        self.recv_impl(buf).await
+    }
+
+    #[cfg(not(target_os = "windows"))]
+    pub async fn recv_impl(&self, buf: &mut [u8]) -> io::Result<usize> {
+        self.tun.read_with(|inner| inner.recv(buf)).await
+    }
+
+    #[cfg(target_os = "windows")]
+    pub async fn recv_impl(&self, buf: &mut [u8]) -> io::Result<usize> {
+        self.tun.read_with(|inner| inner.0.recv(buf)).await
+    }
+}
+
+impl Drop for AsyncTun {
+    fn drop(&mut self) {
+        #[cfg(target_os = "windows")]
+        {
+            // This ensures that `UdpSocket` is dropped properly while not double-closing the RawFd.
+            // SAFETY: `self.io` won't be accessed after this thanks to ManuallyDrop
+            let io = unsafe { ManuallyDrop::take(&mut self.io) };
+            io.into_raw_fd();
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -133,10 +133,16 @@
 // Show required OS/features on docs.rs.
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 
+#[cfg(any(doc, all(feature = "async-io", not(target_os = "windows"))))]
+pub mod async_io;
 #[cfg(any(doc, target_os = "linux"))]
 pub mod linux;
 #[cfg(any(doc, target_os = "macos"))]
 pub mod macos;
+#[cfg(any(doc, all(feature = "mio", not(target_os = "windows"))))]
+pub mod mio;
+#[cfg(any(doc, all(feature = "tokio", not(target_os = "windows"))))]
+pub mod tokio;
 #[cfg(any(
     doc,
     target_os = "dragonfly",

--- a/src/linux.rs
+++ b/src/linux.rs
@@ -9,8 +9,7 @@
 // except according to those terms.
 
 //! Linux-specific TUN/TAP interfaces.
-
-// Values that have yet to be included in libc:
+//!
 
 mod tap;
 mod tun;
@@ -18,6 +17,8 @@ mod tun;
 pub use tap::Tap;
 pub use tun::Tun;
 
+#[cfg(not(target_os = "windows"))]
+use std::os::fd::{AsFd, AsRawFd, BorrowedFd, RawFd};
 use std::{io, net::IpAddr};
 
 use crate::{AddAddress, AddressInfo, DeviceState, Interface};
@@ -101,6 +102,20 @@ impl TunImpl {
     }
 }
 
+#[cfg(not(target_os = "windows"))]
+impl AsFd for TunImpl {
+    fn as_fd(&self) -> BorrowedFd {
+        self.tun.as_fd()
+    }
+}
+
+#[cfg(not(target_os = "windows"))]
+impl AsRawFd for TunImpl {
+    fn as_raw_fd(&self) -> RawFd {
+        self.tun.as_raw_fd()
+    }
+}
+
 pub(crate) struct TapImpl {
     tap: Tap,
 }
@@ -166,5 +181,19 @@ impl TapImpl {
     #[inline]
     pub fn recv(&self, buf: &mut [u8]) -> io::Result<usize> {
         self.tap.recv(buf)
+    }
+}
+
+#[cfg(not(target_os = "windows"))]
+impl AsFd for TapImpl {
+    fn as_fd(&self) -> BorrowedFd {
+        self.tap.as_fd()
+    }
+}
+
+#[cfg(not(target_os = "windows"))]
+impl AsRawFd for TapImpl {
+    fn as_raw_fd(&self) -> RawFd {
+        self.tap.as_raw_fd()
     }
 }

--- a/src/linux/tap.rs
+++ b/src/linux/tap.rs
@@ -10,6 +10,8 @@
 
 use std::ffi::CStr;
 use std::net::IpAddr;
+#[cfg(not(target_os = "windows"))]
+use std::os::fd::{AsFd, AsRawFd, BorrowedFd};
 use std::{io, ptr};
 
 use crate::RawFd;
@@ -408,6 +410,20 @@ impl Tap {
         unsafe {
             debug_assert_eq!(libc::close(fd), 0);
         }
+    }
+}
+
+#[cfg(not(target_os = "windows"))]
+impl AsFd for Tap {
+    fn as_fd(&self) -> BorrowedFd {
+        unsafe { BorrowedFd::borrow_raw(self.fd) }
+    }
+}
+
+#[cfg(not(target_os = "windows"))]
+impl AsRawFd for Tap {
+    fn as_raw_fd(&self) -> RawFd {
+        self.fd
     }
 }
 

--- a/src/linux/tun.rs
+++ b/src/linux/tun.rs
@@ -10,6 +10,8 @@
 
 use std::ffi::CStr;
 use std::net::IpAddr;
+#[cfg(not(target_os = "windows"))]
+use std::os::fd::{AsFd, AsRawFd, BorrowedFd};
 use std::{io, ptr};
 
 use crate::RawFd;
@@ -397,6 +399,20 @@ impl Tun {
         unsafe {
             debug_assert_eq!(libc::close(fd), 0);
         }
+    }
+}
+
+#[cfg(not(target_os = "windows"))]
+impl AsFd for Tun {
+    fn as_fd(&self) -> BorrowedFd {
+        unsafe { BorrowedFd::borrow_raw(self.fd) }
+    }
+}
+
+#[cfg(not(target_os = "windows"))]
+impl AsRawFd for Tun {
+    fn as_raw_fd(&self) -> RawFd {
+        self.fd
     }
 }
 

--- a/src/macos.rs
+++ b/src/macos.rs
@@ -20,6 +20,8 @@ pub use feth::FethTap;
 pub use utun::Utun;
 
 use std::net::IpAddr;
+#[cfg(not(target_os = "windows"))]
+use std::os::fd::{AsFd, AsRawFd, BorrowedFd, RawFd};
 
 use crate::{AddAddress, AddressInfo, DeviceState, Interface};
 
@@ -91,6 +93,20 @@ impl TunImpl {
     }
 }
 
+#[cfg(not(target_os = "windows"))]
+impl AsFd for TunImpl {
+    fn as_fd(&self) -> BorrowedFd {
+        self.tun.as_fd()
+    }
+}
+
+#[cfg(not(target_os = "windows"))]
+impl AsRawFd for TunImpl {
+    fn as_raw_fd(&self) -> RawFd {
+        self.tun.as_raw_fd()
+    }
+}
+
 pub(crate) struct TapImpl {
     tap: FethTap,
 }
@@ -158,5 +174,19 @@ impl TapImpl {
     #[inline]
     pub fn recv(&self, buf: &mut [u8]) -> io::Result<usize> {
         self.tap.recv(buf)
+    }
+}
+
+#[cfg(not(target_os = "windows"))]
+impl AsFd for TapImpl {
+    fn as_fd(&self) -> BorrowedFd {
+        self.tap.as_fd()
+    }
+}
+
+#[cfg(not(target_os = "windows"))]
+impl AsRawFd for TapImpl {
+    fn as_raw_fd(&self) -> RawFd {
+        self.tap.as_raw_fd()
     }
 }

--- a/src/macos/feth.rs
+++ b/src/macos/feth.rs
@@ -10,6 +10,8 @@
 
 use std::ffi::{CStr, CString};
 use std::net::IpAddr;
+#[cfg(not(target_os = "windows"))]
+use std::os::fd::{AsFd, AsRawFd, BorrowedFd};
 use std::{array, cmp, io, mem, ptr};
 
 use crate::libc_extra::*;
@@ -1015,6 +1017,20 @@ impl FethTap {
         unsafe {
             debug_assert_eq!(libc::close(fd), 0);
         }
+    }
+}
+
+#[cfg(not(target_os = "windows"))]
+impl AsFd for FethTap {
+    fn as_fd(&self) -> BorrowedFd {
+        unsafe { BorrowedFd::borrow_raw(self.bpf_fd) }
+    }
+}
+
+#[cfg(not(target_os = "windows"))]
+impl AsRawFd for FethTap {
+    fn as_raw_fd(&self) -> RawFd {
+        self.bpf_fd
     }
 }
 

--- a/src/macos/utun.rs
+++ b/src/macos/utun.rs
@@ -10,7 +10,7 @@
 
 use std::net::IpAddr;
 #[cfg(not(target_os = "windows"))]
-use std::os::fd::AsRawFd;
+use std::os::fd::{AsFd, AsRawFd, BorrowedFd};
 use std::{array, io, mem, ptr, str};
 
 use crate::libc_extra::*;
@@ -428,9 +428,10 @@ impl Utun {
     }
 }
 
-impl Drop for Utun {
-    fn drop(&mut self) {
-        self.destroy_impl().unwrap();
+#[cfg(not(target_os = "windows"))]
+impl AsFd for Utun {
+    fn as_fd(&self) -> BorrowedFd {
+        unsafe { BorrowedFd::borrow_raw(self.fd) }
     }
 }
 
@@ -438,5 +439,11 @@ impl Drop for Utun {
 impl AsRawFd for Utun {
     fn as_raw_fd(&self) -> RawFd {
         self.fd
+    }
+}
+
+impl Drop for Utun {
+    fn drop(&mut self) {
+        self.destroy_impl().unwrap();
     }
 }

--- a/src/mio.rs
+++ b/src/mio.rs
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+//
+// Copyright (c) 2024 Nathaniel Bennett <me[at]nathanielbennett[dotcom]>
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+//! Async `Tun`/`Tap` interfaces compatible with `mio`.
+
+#[cfg(not(target_os = "windows"))]
+mod tap;
+mod tun;
+
+#[cfg(not(target_os = "windows"))]
+pub use tap::AsyncTap;
+pub use tun::AsyncTun;
+
+// mio:
+// No current solution
+
+// tokio:
+// `tokio::io::unix::AsyncFd`
+//
+// Windows variant currently blocking on issue:
+// https://github.com/tokio-rs/tokio/issues/3781
+
+// Workaround: `FromRawHandle` for `File`
+
+// async-std:
+// FromRawFd for UdpStream
+// FromRawHandle for File
+
+// smol:
+// `async-io` crate
+// `async-io::Async<T>`
+
+// ```
+// impl<T: AsFd> Async<T>
+//
+// pub fn new(io: T) -> Result<Async<T>>
+//
+// Creates an async I/O handle.
+//
+// This method will put the handle in non-blocking mode and register it in epoll/kqueue/event ports/IOCP.
+//
+// On Unix systems, the handle must implement AsFd, while on Windows it must implement AsSocket.
+// ```
+//
+// Workaround: use `FromRawHandle` for `File` type for reads.
+
+// So convert pointer to u64; it's safe.

--- a/src/mio/tap.rs
+++ b/src/mio/tap.rs
@@ -1,0 +1,177 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+//
+// Copyright (c) 2024 Nathaniel Bennett <me[at]nathanielbennett[dotcom]>
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use std::io;
+use std::mem::ManuallyDrop;
+#[cfg(not(target_os = "windows"))]
+use std::net::IpAddr;
+#[cfg(not(target_os = "windows"))]
+use std::os::fd::{AsRawFd, FromRawFd, IntoRawFd};
+#[cfg(target_os = "windows")]
+use std::os::windows::io::{FromRawSocket, RawSocket};
+
+#[cfg(not(target_os = "windows"))]
+use crate::{AddAddress, AddressInfo};
+use crate::{DeviceState, Interface, Tap};
+
+use mio::event::Source;
+use mio::net::UdpSocket;
+use mio::{Interest, Registry, Token};
+
+/// A cross-platform asynchronous TAP interface, suitable for tunnelling link-layer packets.
+pub struct AsyncTap {
+    tap: Tap,
+    io: ManuallyDrop<UdpSocket>,
+}
+
+impl AsyncTap {
+    /// Creates a new, unique TAP device.
+    #[inline]
+    pub fn new() -> io::Result<Self> {
+        let mut tap = Tap::new()?;
+        tap.set_nonblocking(true)?;
+
+        // SAFETY: `AsyncTap` ensures that the RawFd is extracted from `io` in its drop()
+        // implementation so that the descriptor isn't closed twice.
+        #[cfg(not(target_os = "windows"))]
+        let io = unsafe { UdpSocket::from_raw_fd(tap.as_raw_fd()) };
+        #[cfg(target_os = "windows")]
+        let io = unsafe { UdpSocket::from_raw_socket(tap.read_handle() as RawSocket) };
+
+        Ok(Self {
+            tap,
+            io: ManuallyDrop::new(io),
+        })
+    }
+
+    /// Opens or creates a TAP device of the given name.
+    #[inline]
+    pub fn new_named(if_name: Interface) -> io::Result<Self> {
+        let mut tap = Tap::new_named(if_name)?;
+        tap.set_nonblocking(true)?;
+
+        // SAFETY: `AsyncTap` ensures that the RawFd is extracted from `io` in its drop()
+        // implementation so that the descriptor isn't closed twice.
+        #[cfg(not(target_os = "windows"))]
+        let io = unsafe { UdpSocket::from_raw_fd(tap.as_raw_fd()) };
+        #[cfg(target_os = "windows")]
+        let io = unsafe { UdpSocket::from_raw_socket(tun.read_handle() as RawSocket) };
+
+        Ok(Self {
+            tap,
+            io: ManuallyDrop::new(io),
+        })
+    }
+
+    /// Retrieves the interface name of the TAP device.
+    #[inline]
+    pub fn name(&self) -> io::Result<Interface> {
+        self.tap.name()
+    }
+
+    /// Sets the adapter state of the TAP device (e.g. "up" or "down").
+    #[inline]
+    pub fn set_state(&mut self, state: DeviceState) -> io::Result<()> {
+        self.tap.set_state(state)
+    }
+
+    /// Sets the adapter state of the TAP device to "up".
+    #[inline]
+    pub fn set_up(&mut self) -> io::Result<()> {
+        self.tap.set_state(DeviceState::Up)
+    }
+
+    /// Sets the adapter state of the TAP device to "down".
+    #[inline]
+    pub fn set_down(&mut self) -> io::Result<()> {
+        self.tap.set_state(DeviceState::Down)
+    }
+
+    /// Retrieves the Maximum Transmission Unit (MTU) of the TAP device.
+    #[inline]
+    pub fn mtu(&self) -> io::Result<usize> {
+        self.tap.mtu()
+    }
+
+    /// Retrieves the network-layer addresses assigned to the interface.
+    ///
+    /// Most platforms automatically assign a link-local IPv6 address to TAP devices on creation.
+    /// Developers should take this into account and avoid the incorrect assumption that `addrs()`
+    /// will return only the addresses they have assigned via [`add_addr()`](Self::add_addr).
+    /// [`add_addr()`](Self::add_addr).
+    #[cfg(not(target_os = "windows"))]
+    #[inline]
+    pub fn addrs(&self) -> io::Result<Vec<AddressInfo>> {
+        self.tap.addrs()
+    }
+
+    // TODO: this used to be the case, but now it's not??
+    //    /// MacOS additionally requires a destination address when assigning an IPv6 address to a TAP
+    //    /// device. Neither FreeBSD nor DragonFlyBSD include this restriction.
+
+    /// Assigns a network-layer address to the interface.
+    #[cfg(not(target_os = "windows"))]
+    #[inline]
+    pub fn add_addr<A: Into<AddAddress>>(&self, req: A) -> io::Result<()> {
+        self.tap.add_addr(req)
+    }
+
+    /// Removes the specified network-layer address from the interface.
+    #[cfg(not(target_os = "windows"))]
+    #[inline]
+    pub fn remove_addr(&self, addr: IpAddr) -> io::Result<()> {
+        self.tap.remove_addr(addr)
+    }
+
+    /// Sends a packet over the TAP device.
+    #[inline]
+    pub fn send(&self, buf: &[u8]) -> io::Result<usize> {
+        self.tap.send(buf)
+    }
+
+    /// Receives a packet over the TAP device.
+    #[inline]
+    pub fn recv(&self, buf: &mut [u8]) -> io::Result<usize> {
+        self.io.recv(buf)
+    }
+}
+
+impl Source for AsyncTap {
+    fn register(
+        &mut self,
+        registry: &Registry,
+        token: Token,
+        interests: Interest,
+    ) -> io::Result<()> {
+        self.io.register(registry, token, interests)
+    }
+
+    fn reregister(
+        &mut self,
+        registry: &Registry,
+        token: Token,
+        interests: Interest,
+    ) -> io::Result<()> {
+        self.io.reregister(registry, token, interests)
+    }
+
+    fn deregister(&mut self, registry: &Registry) -> io::Result<()> {
+        self.io.deregister(registry)
+    }
+}
+
+impl Drop for AsyncTap {
+    fn drop(&mut self) {
+        // This ensures that `UdpSocket` is dropped properly while not double-closing the RawFd.
+        // SAFETY: `self.io` won't be accessed after this thanks to ManuallyDrop
+        let io = unsafe { ManuallyDrop::take(&mut self.io) };
+        io.into_raw_fd();
+    }
+}

--- a/src/mio/tun.rs
+++ b/src/mio/tun.rs
@@ -1,0 +1,191 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+//
+// Copyright (c) 2024 Nathaniel Bennett <me[at]nathanielbennett[dotcom]>
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use std::io;
+use std::mem::ManuallyDrop;
+#[cfg(not(target_os = "windows"))]
+use std::net::IpAddr;
+#[cfg(not(target_os = "windows"))]
+use std::os::fd::{AsRawFd, FromRawFd, IntoRawFd};
+#[cfg(target_os = "windows")]
+use std::os::windows::io::{FromRawSocket, RawSocket};
+
+#[cfg(not(target_os = "windows"))]
+use crate::{AddAddress, AddressInfo};
+use crate::{DeviceState, Interface, Tun};
+
+use mio::event::Source;
+use mio::net::UdpSocket;
+use mio::{Interest, Registry, Token};
+
+/// A cross-platform asynchronous TUN interface, suitable for tunnelling network-layer packets.
+pub struct AsyncTun {
+    tun: Tun,
+    io: ManuallyDrop<UdpSocket>,
+}
+
+impl AsyncTun {
+    /// Creates a new, unique TUN device.
+    #[inline]
+    pub fn new() -> io::Result<Self> {
+        let mut tun = Tun::new()?;
+        tun.set_nonblocking(true)?;
+
+        // SAFETY: `AsyncTun` ensures that the RawFd is extracted from `io` in its drop()
+        // implementation so that the descriptor isn't closed twice.
+        #[cfg(not(target_os = "windows"))]
+        let io = unsafe { UdpSocket::from_raw_fd(tun.as_raw_fd()) };
+        #[cfg(target_os = "windows")]
+        let io = unsafe { UdpSocket::from_raw_socket(tun.read_handle() as RawSocket) };
+
+        Ok(Self {
+            tun,
+            io: ManuallyDrop::new(io),
+        })
+    }
+
+    /// Opens or creates a TUN device of the given name.
+    #[inline]
+    pub fn new_named(if_name: Interface) -> io::Result<Self> {
+        let mut tun = Tun::new_named(if_name)?;
+        tun.set_nonblocking(true)?;
+
+        // SAFETY: `AsyncTun` ensures that the RawFd is extracted from `io` in its drop()
+        // implementation so that the descriptor isn't closed twice.
+        #[cfg(not(target_os = "windows"))]
+        let io = unsafe { UdpSocket::from_raw_fd(tun.as_raw_fd()) };
+        #[cfg(target_os = "windows")]
+        let io = unsafe { UdpSocket::from_raw_socket(tun.read_handle() as RawSocket) };
+
+        Ok(Self {
+            tun,
+            io: ManuallyDrop::new(io),
+        })
+    }
+
+    /// Retrieves the interface name of the TUN device.
+    #[inline]
+    pub fn name(&self) -> io::Result<Interface> {
+        self.tun.name()
+    }
+
+    /// Sets the adapter state of the TUN device (e.g. "up" or "down").
+    #[inline]
+    pub fn set_state(&mut self, state: DeviceState) -> io::Result<()> {
+        self.tun.set_state(state)
+    }
+
+    /// Sets the adapter state of the TUN device to "up".
+    #[inline]
+    pub fn set_up(&mut self) -> io::Result<()> {
+        self.tun.set_state(DeviceState::Up)
+    }
+
+    /// Sets the adapter state of the TUN device to "down".
+    #[inline]
+    pub fn set_down(&mut self) -> io::Result<()> {
+        self.tun.set_state(DeviceState::Down)
+    }
+
+    /// Retrieves the Maximum Transmission Unit (MTU) of the TUN device.
+    #[inline]
+    pub fn mtu(&self) -> io::Result<usize> {
+        self.tun.mtu()
+    }
+
+    /// Retrieves the IP addresses assigned to the interface.
+    ///
+    /// # Portability
+    ///
+    /// In nearly all platforms, no addresses are automatically assigned to TUN interfaces. The
+    /// exception to this is OpenBSD, which automatically assigns a link-layer IPv6 address (in
+    /// addition to the specified IPv6 address) the first time an IPv6 address is assigned to a
+    /// TUN device. As such, portable applications **should not** rely on the assumption that the
+    /// only addresses returned from this method are those that were previously assigned via
+    /// [`add_addr()`](Self::add_addr).
+    #[cfg(not(target_os = "windows"))]
+    #[inline]
+    pub fn addrs(&self) -> io::Result<Vec<AddressInfo>> {
+        self.tun.addrs()
+    }
+
+    // TODO: this used to be the case, but now it's not??
+    //    /// MacOS additionally requires a destination address when assigning an IPv6 address to a TUN
+    //    /// device. Neither FreeBSD nor DragonFlyBSD include this restriction.
+
+    /// Assigns an IP address to the interface.
+    ///
+    /// # Portability
+    ///
+    /// MacOS, FreeBSD and DragonFlyBSD all require a destination address when assigning an IPv4
+    /// address to a TUN device. The destination address is optional for other platforms.
+    ///
+    /// Most platforms automatically assign a link-local IPv6 address to a newly created TAP device.
+    /// No platforms assign link-local IPv6 addresses to TUN devices on creation. However, OpenBSD
+    /// **will** assign a link-local IPv6 address (in addition to the specified IPv6 address) the
+    /// first time an IPv6 address is assigned to a TUN device.
+    #[cfg(not(target_os = "windows"))]
+    #[inline]
+    pub fn add_addr<A: Into<AddAddress>>(&self, req: A) -> io::Result<()> {
+        self.tun.add_addr(req)
+    }
+
+    /// Removes the specified network-layer address from the interface.
+    #[cfg(not(target_os = "windows"))]
+    #[inline]
+    pub fn remove_addr(&self, addr: IpAddr) -> io::Result<()> {
+        self.tun.remove_addr(addr)
+    }
+
+    /// Sends a packet over the TUN device.
+    #[inline]
+    pub fn send(&self, buf: &[u8]) -> io::Result<usize> {
+        self.tun.send(buf)
+    }
+
+    /// Receives a packet over the TUN device.
+    #[inline]
+    pub fn recv(&self, buf: &mut [u8]) -> io::Result<usize> {
+        self.io.recv(buf)
+    }
+}
+
+impl Source for AsyncTun {
+    fn register(
+        &mut self,
+        registry: &Registry,
+        token: Token,
+        interests: Interest,
+    ) -> io::Result<()> {
+        self.io.register(registry, token, interests)
+    }
+
+    fn reregister(
+        &mut self,
+        registry: &Registry,
+        token: Token,
+        interests: Interest,
+    ) -> io::Result<()> {
+        self.io.reregister(registry, token, interests)
+    }
+
+    fn deregister(&mut self, registry: &Registry) -> io::Result<()> {
+        self.io.deregister(registry)
+    }
+}
+
+impl Drop for AsyncTun {
+    fn drop(&mut self) {
+        // This ensures that `UdpSocket` is dropped properly while not double-closing the RawFd.
+        // SAFETY: `self.io` won't be accessed after this thanks to ManuallyDrop
+        let io = unsafe { ManuallyDrop::take(&mut self.io) };
+        io.into_raw_fd();
+    }
+}

--- a/src/tap.rs
+++ b/src/tap.rs
@@ -8,7 +8,11 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::{io, net::IpAddr};
+use std::io;
+use std::net::IpAddr;
+
+#[cfg(not(target_os = "windows"))]
+use std::os::fd::{AsFd, AsRawFd, BorrowedFd, RawFd};
 
 #[cfg(not(target_os = "windows"))]
 use crate::AddAddress;
@@ -127,6 +131,20 @@ impl Tap {
     #[inline]
     pub fn recv(&self, buf: &mut [u8]) -> io::Result<usize> {
         self.inner.recv(buf)
+    }
+}
+
+#[cfg(not(target_os = "windows"))]
+impl AsRawFd for Tap {
+    fn as_raw_fd(&self) -> RawFd {
+        self.inner.as_raw_fd()
+    }
+}
+
+#[cfg(not(target_os = "windows"))]
+impl AsFd for Tap {
+    fn as_fd(&self) -> BorrowedFd {
+        self.inner.as_fd()
     }
 }
 

--- a/src/tokio.rs
+++ b/src/tokio.rs
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+//
+// Copyright (c) 2024 Nathaniel Bennett <me[at]nathanielbennett[dotcom]>
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+//! Async `Tun`/`Tap` interfaces compatible with `tokio`.
+
+#[cfg(not(target_os = "windows"))]
+mod tap;
+mod tun;
+
+#[cfg(not(target_os = "windows"))]
+pub use tap::AsyncTap;
+pub use tun::AsyncTun;

--- a/src/tokio/tap.rs
+++ b/src/tokio/tap.rs
@@ -1,0 +1,243 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+//
+// Copyright (c) 2024 Nathaniel Bennett <me[at]nathanielbennett[dotcom]>
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use std::io;
+#[cfg(target_os = "windows")]
+use std::mem::ManuallyDrop;
+#[cfg(not(target_os = "windows"))]
+use std::net::IpAddr;
+#[cfg(target_os = "windows")]
+use std::os::windows::io::{FromRawSocket, RawSocket};
+#[cfg(target_os = "windows")]
+use std::time::Duration;
+
+#[cfg(not(target_os = "windows"))]
+use crate::{AddAddress, AddressInfo};
+use crate::{DeviceState, Interface, Tap};
+
+#[cfg(not(target_os = "windows"))]
+use tokio::io::unix::AsyncFd;
+#[cfg(target_os = "windows")]
+use tokio::io::Interest;
+#[cfg(target_os = "windows")]
+use tokio::net::UdpSocket;
+
+/// A cross-platform asynchronous TAP interface, suitable for tunnelling link-layer packets.
+pub struct AsyncTap {
+    #[cfg(not(target_os = "windows"))]
+    tap: AsyncFd<Tap>,
+    #[cfg(target_os = "windows")]
+    tap: Tap,
+    #[cfg(target_os = "windows")]
+    io: ManuallyDrop<UdpSocket>,
+}
+
+impl AsyncTap {
+    /// Creates a new, unique TAP device.
+    #[inline]
+    pub fn new() -> io::Result<Self> {
+        Self::new_impl()
+    }
+
+    #[cfg(target_os = "windows")]
+    fn new_impl() -> io::Result<Self> {
+        let mut tap = Tap::new()?;
+        tap.set_nonblocking(true)?;
+
+        // SAFETY: `AsyncTap` ensures that the RawFd is extracted from `io` in its drop()
+        // implementation so that the descriptor isn't closed twice.
+        let io = unsafe { UdpSocket::from_raw_socket(tap.read_handle() as RawSocket) };
+
+        Ok(Self {
+            tap,
+            io: ManuallyDrop::new(io),
+        })
+    }
+
+    #[cfg(not(target_os = "windows"))]
+    fn new_impl() -> io::Result<Self> {
+        let mut tap = Tap::new()?;
+        tap.set_nonblocking(true)?;
+
+        Ok(Self {
+            tap: AsyncFd::new(tap)?,
+        })
+    }
+
+    /// Opens or creates a TAP device of the given name.
+    #[inline]
+    pub fn new_named(if_name: Interface) -> io::Result<Self> {
+        Self::new_named_impl(if_name)
+    }
+
+    #[cfg(not(target_os = "windows"))]
+    pub fn new_named_impl(if_name: Interface) -> io::Result<Self> {
+        let mut tap = Tap::new_named(if_name)?;
+        tap.set_nonblocking(true)?;
+
+        Ok(Self {
+            tap: AsyncFd::new(tap)?,
+        })
+    }
+
+    #[cfg(target_os = "windows")]
+    pub fn new_named_impl(if_name: Interface) -> io::Result<Self> {
+        let mut tap = Tap::new_named(if_name)?;
+        tap.set_nonblocking(true)?;
+
+        // SAFETY: `AsyncTap` ensures that the RawFd is extracted from `io` in its drop()
+        // implementation so that the descriptor isn't closed twice.
+        #[cfg(target_os = "windows")]
+        let io = unsafe { UdpSocket::from_raw_socket(tun.read_handle() as RawSocket) };
+
+        Ok(Self {
+            tap,
+            io: ManuallyDrop::new(io),
+        })
+    }
+
+    /// Retrieves the interface name of the TAP device.
+    #[inline]
+    pub fn name(&self) -> io::Result<Interface> {
+        self.tap.get_ref().name()
+    }
+
+    /// Sets the adapter state of the TAP device (e.g. "up" or "down").
+    #[inline]
+    pub fn set_state(&mut self, state: DeviceState) -> io::Result<()> {
+        self.tap.get_mut().set_state(state)
+    }
+
+    /// Sets the adapter state of the TAP device to "up".
+    #[inline]
+    pub fn set_up(&mut self) -> io::Result<()> {
+        self.tap.get_mut().set_state(DeviceState::Up)
+    }
+
+    /// Sets the adapter state of the TAP device to "down".
+    #[inline]
+    pub fn set_down(&mut self) -> io::Result<()> {
+        self.tap.get_mut().set_state(DeviceState::Down)
+    }
+
+    /// Retrieves the Maximum Transmission Unit (MTU) of the TAP device.
+    #[inline]
+    pub fn mtu(&self) -> io::Result<usize> {
+        self.tap.get_ref().mtu()
+    }
+
+    /// Retrieves the network-layer addresses assigned to the interface.
+    ///
+    /// Most platforms automatically assign a link-local IPv6 address to TAP devices on creation.
+    /// Developers should take this into account and avoid the incorrect assumption that `addrs()`
+    /// will return only the addresses they have assigned via [`add_addr()`](Self::add_addr).
+    /// [`add_addr()`](Self::add_addr).
+    #[cfg(not(target_os = "windows"))]
+    #[inline]
+    pub fn addrs(&self) -> io::Result<Vec<AddressInfo>> {
+        self.tap.get_ref().addrs()
+    }
+
+    // TODO: this used to be the case, but now it's not??
+    //    /// MacOS additionally requires a destination address when assigning an IPv6 address to a TAP
+    //    /// device. Neither FreeBSD nor DragonFlyBSD include this restriction.
+
+    /// Assigns a network-layer address to the interface.
+    #[cfg(not(target_os = "windows"))]
+    #[inline]
+    pub fn add_addr<A: Into<AddAddress>>(&self, req: A) -> io::Result<()> {
+        self.tap.get_ref().add_addr(req)
+    }
+
+    /// Removes the specified network-layer address from the interface.
+    #[cfg(not(target_os = "windows"))]
+    #[inline]
+    pub fn remove_addr(&self, addr: IpAddr) -> io::Result<()> {
+        self.tap.get_ref().remove_addr(addr)
+    }
+
+    /// Sends a packet over the TAP device.
+    #[inline]
+    pub async fn send(&self, buf: &[u8]) -> io::Result<usize> {
+        self.send_impl(buf).await
+    }
+
+    #[cfg(not(target_os = "windows"))]
+    #[inline]
+    async fn send_impl(&self, buf: &[u8]) -> io::Result<usize> {
+        loop {
+            let mut guard = self.tap.readable().await?;
+
+            match guard.try_io(|inner| inner.get_ref().send(buf)) {
+                Ok(result) => return result,
+                Err(_would_block) => continue,
+            }
+        }
+    }
+
+    #[cfg(target_os = "windows")]
+    #[inline]
+    async fn send_impl(&self, buf: &[u8]) -> io::Result<usize> {
+        const SEND_MAX_BLOCKING_INTERVAL: u64 = 100;
+        let mut timeout = 1; // Start with 1 millisecond timeout
+
+        loop {
+            match self.tun.send(buf) {
+                Err(e) if e.kind() == io::ErrorKind::WouldBlock => {
+                    tokio::time::sleep(Duration::from_millis(timeout)).await;
+                    timeout = cmp::min(timeout * 2, SEND_MAX_BLOCKING_INTERVAL);
+                }
+                res => return res,
+            }
+        }
+    }
+
+    /// Receives a packet over the TAP device.
+    #[inline]
+    pub async fn recv(&self, buf: &mut [u8]) -> io::Result<usize> {
+        self.recv_impl(buf).await
+    }
+
+    #[cfg(not(target_os = "windows"))]
+    pub async fn recv_impl(&self, buf: &mut [u8]) -> io::Result<usize> {
+        loop {
+            let mut guard = self.tap.writable().await?;
+
+            match guard.try_io(|inner| inner.get_ref().recv(buf)) {
+                Ok(result) => return result,
+                Err(_would_block) => continue,
+            }
+        }
+    }
+
+    #[cfg(target_os = "windows")]
+    pub async fn recv_impl(&self, buf: &mut [u8]) -> io::Result<usize> {
+        loop {
+            let mut guard = self.io.readable().await?;
+
+            match guard.try_io(Interest::READABLE, |inner| self.tap.recv(buf)) {
+                Ok(result) => return result,
+                Err(_would_block) => continue,
+            }
+        }
+    }
+}
+
+impl Drop for AsyncTap {
+    fn drop(&mut self) {
+        #[cfg(target_os = "windows")]
+        {
+            // This ensures that `UdpSocket` is dropped properly while not double-closing the RawFd.
+            // SAFETY: `self.io` won't be accessed after this thanks to ManuallyDrop
+            let io = unsafe { ManuallyDrop::take(&mut self.io) };
+            io.into_raw_fd();
+        }
+    }
+}

--- a/src/tokio/tun.rs
+++ b/src/tokio/tun.rs
@@ -1,0 +1,243 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+//
+// Copyright (c) 2024 Nathaniel Bennett <me[at]nathanielbennett[dotcom]>
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use std::io;
+#[cfg(target_os = "windows")]
+use std::mem::ManuallyDrop;
+#[cfg(not(target_os = "windows"))]
+use std::net::IpAddr;
+#[cfg(target_os = "windows")]
+use std::os::windows::io::{FromRawSocket, RawSocket};
+#[cfg(target_os = "windows")]
+use std::time::Duration;
+
+#[cfg(not(target_os = "windows"))]
+use crate::{AddAddress, AddressInfo};
+use crate::{DeviceState, Interface, Tun};
+
+#[cfg(not(target_os = "windows"))]
+use tokio::io::unix::AsyncFd;
+#[cfg(target_os = "windows")]
+use tokio::io::Interest;
+#[cfg(target_os = "windows")]
+use tokio::net::UdpSocket;
+
+/// A cross-platform asynchronous TUN interface, suitable for tunnelling network-layer packets.
+pub struct AsyncTun {
+    #[cfg(not(target_os = "windows"))]
+    tun: AsyncFd<Tun>,
+    #[cfg(target_os = "windows")]
+    tun: Tun,
+    #[cfg(target_os = "windows")]
+    io: ManuallyDrop<UdpSocket>,
+}
+
+impl AsyncTun {
+    /// Creates a new, unique TUN device.
+    #[inline]
+    pub fn new() -> io::Result<Self> {
+        Self::new_impl()
+    }
+
+    #[cfg(target_os = "windows")]
+    fn new_impl() -> io::Result<Self> {
+        let mut tun = Tun::new()?;
+        tun.set_nonblocking(true)?;
+
+        // SAFETY: `AsyncTun` ensures that the RawFd is extracted from `io` in its drop()
+        // implementation so that the descriptor isn't closed twice.
+        let io = unsafe { UdpSocket::from_raw_socket(tun.read_handle() as RawSocket) };
+
+        Ok(Self {
+            tun,
+            io: ManuallyDrop::new(io),
+        })
+    }
+
+    #[cfg(not(target_os = "windows"))]
+    fn new_impl() -> io::Result<Self> {
+        let mut tun = Tun::new()?;
+        tun.set_nonblocking(true)?;
+
+        Ok(Self {
+            tun: AsyncFd::new(tun)?,
+        })
+    }
+
+    /// Opens or creates a TUN device of the given name.
+    #[inline]
+    pub fn new_named(if_name: Interface) -> io::Result<Self> {
+        Self::new_named_impl(if_name)
+    }
+
+    #[cfg(not(target_os = "windows"))]
+    pub fn new_named_impl(if_name: Interface) -> io::Result<Self> {
+        let mut tun = Tun::new_named(if_name)?;
+        tun.set_nonblocking(true)?;
+
+        Ok(Self {
+            tun: AsyncFd::new(tun)?,
+        })
+    }
+
+    #[cfg(target_os = "windows")]
+    pub fn new_named_impl(if_name: Interface) -> io::Result<Self> {
+        let mut tun = Tun::new_named(if_name)?;
+        tun.set_nonblocking(true)?;
+
+        // SAFETY: `AsyncTun` ensures that the RawFd is extracted from `io` in its drop()
+        // implementation so that the descriptor isn't closed twice.
+        #[cfg(target_os = "windows")]
+        let io = unsafe { UdpSocket::from_raw_socket(tun.read_handle() as RawSocket) };
+
+        Ok(Self {
+            tun,
+            io: ManuallyDrop::new(io),
+        })
+    }
+
+    /// Retrieves the interface name of the TUN device.
+    #[inline]
+    pub fn name(&self) -> io::Result<Interface> {
+        self.tun.get_ref().name()
+    }
+
+    /// Sets the adapter state of the TUN device (e.g. "up" or "down").
+    #[inline]
+    pub fn set_state(&mut self, state: DeviceState) -> io::Result<()> {
+        self.tun.get_mut().set_state(state)
+    }
+
+    /// Sets the adapter state of the TUN device to "up".
+    #[inline]
+    pub fn set_up(&mut self) -> io::Result<()> {
+        self.tun.get_mut().set_state(DeviceState::Up)
+    }
+
+    /// Sets the adapter state of the TUN device to "down".
+    #[inline]
+    pub fn set_down(&mut self) -> io::Result<()> {
+        self.tun.get_mut().set_state(DeviceState::Down)
+    }
+
+    /// Retrieves the Maximum Transmission Unit (MTU) of the TUN device.
+    #[inline]
+    pub fn mtu(&self) -> io::Result<usize> {
+        self.tun.get_ref().mtu()
+    }
+
+    /// Retrieves the network-layer addresses assigned to the interface.
+    ///
+    /// Most platforms automatically assign a link-local IPv6 address to TUN devices on creation.
+    /// Developers should take this into account and avoid the incorrect assumption that `addrs()`
+    /// will return only the addresses they have assigned via [`add_addr()`](Self::add_addr).
+    /// [`add_addr()`](Self::add_addr).
+    #[cfg(not(target_os = "windows"))]
+    #[inline]
+    pub fn addrs(&self) -> io::Result<Vec<AddressInfo>> {
+        self.tun.get_ref().addrs()
+    }
+
+    // TODO: this used to be the case, but now it's not??
+    //    /// MacOS additionally requires a destination address when assigning an IPv6 address to a TUN
+    //    /// device. Neither FreeBSD nor DragonFlyBSD include this restriction.
+
+    /// Assigns a network-layer address to the interface.
+    #[cfg(not(target_os = "windows"))]
+    #[inline]
+    pub fn add_addr<A: Into<AddAddress>>(&self, req: A) -> io::Result<()> {
+        self.tun.get_ref().add_addr(req)
+    }
+
+    /// Removes the specified network-layer address from the interface.
+    #[cfg(not(target_os = "windows"))]
+    #[inline]
+    pub fn remove_addr(&self, addr: IpAddr) -> io::Result<()> {
+        self.tun.get_ref().remove_addr(addr)
+    }
+
+    /// Sends a packet over the TUN device.
+    #[inline]
+    pub async fn send(&self, buf: &[u8]) -> io::Result<usize> {
+        self.send_impl(buf).await
+    }
+
+    #[cfg(not(target_os = "windows"))]
+    #[inline]
+    async fn send_impl(&self, buf: &[u8]) -> io::Result<usize> {
+        loop {
+            let mut guard = self.tun.readable().await?;
+
+            match guard.try_io(|inner| inner.get_ref().send(buf)) {
+                Ok(result) => return result,
+                Err(_would_block) => continue,
+            }
+        }
+    }
+
+    #[cfg(target_os = "windows")]
+    #[inline]
+    async fn send_impl(&self, buf: &[u8]) -> io::Result<usize> {
+        const SEND_MAX_BLOCKING_INTERVAL: u64 = 100;
+        let mut timeout = 1; // Start with 1 millisecond timeout
+
+        loop {
+            match self.tun.send(buf) {
+                Err(e) if e.kind() == io::ErrorKind::WouldBlock => {
+                    tokio::time::sleep(Duration::from_millis(timeout)).await;
+                    timeout = cmp::min(timeout * 2, SEND_MAX_BLOCKING_INTERVAL);
+                }
+                res => return res,
+            }
+        }
+    }
+
+    /// Receives a packet over the TUN device.
+    #[inline]
+    pub async fn recv(&self, buf: &mut [u8]) -> io::Result<usize> {
+        self.recv_impl(buf).await
+    }
+
+    #[cfg(not(target_os = "windows"))]
+    pub async fn recv_impl(&self, buf: &mut [u8]) -> io::Result<usize> {
+        loop {
+            let mut guard = self.tun.writable().await?;
+
+            match guard.try_io(|inner| inner.get_ref().recv(buf)) {
+                Ok(result) => return result,
+                Err(_would_block) => continue,
+            }
+        }
+    }
+
+    #[cfg(target_os = "windows")]
+    pub async fn recv_impl(&self, buf: &mut [u8]) -> io::Result<usize> {
+        loop {
+            let mut guard = self.io.readable().await?;
+
+            match guard.try_io(Interest::READABLE, |inner| self.tun.recv(buf)) {
+                Ok(result) => return result,
+                Err(_would_block) => continue,
+            }
+        }
+    }
+}
+
+impl Drop for AsyncTun {
+    fn drop(&mut self) {
+        #[cfg(target_os = "windows")]
+        {
+            // This ensures that `UdpSocket` is dropped properly while not double-closing the RawFd.
+            // SAFETY: `self.io` won't be accessed after this thanks to ManuallyDrop
+            let io = unsafe { ManuallyDrop::take(&mut self.io) };
+            io.into_raw_fd();
+        }
+    }
+}

--- a/src/tun.rs
+++ b/src/tun.rs
@@ -9,9 +9,10 @@
 // except according to those terms.
 
 use std::io;
-
 #[cfg(not(target_os = "windows"))]
 use std::net::IpAddr;
+#[cfg(not(target_os = "windows"))]
+use std::os::fd::{AsFd, AsRawFd, BorrowedFd, RawFd};
 
 #[cfg(not(target_os = "windows"))]
 use crate::AddAddress;
@@ -171,6 +172,20 @@ impl Tun {
     #[inline]
     pub fn read_handle(&mut self) -> HANDLE {
         self.inner.read_handle()
+    }
+}
+
+#[cfg(not(target_os = "windows"))]
+impl AsRawFd for Tun {
+    fn as_raw_fd(&self) -> RawFd {
+        self.inner.as_raw_fd()
+    }
+}
+
+#[cfg(not(target_os = "windows"))]
+impl AsFd for Tun {
+    fn as_fd(&self) -> BorrowedFd {
+        self.inner.as_fd()
     }
 }
 

--- a/src/unix.rs
+++ b/src/unix.rs
@@ -21,6 +21,8 @@ pub use tap::Tap;
 pub use tun::Tun;
 
 use std::net::IpAddr;
+#[cfg(not(target_os = "windows"))]
+use std::os::fd::{AsFd, AsRawFd, BorrowedFd, RawFd};
 use std::{io, ptr};
 
 use crate::libc_extra::*;
@@ -106,6 +108,20 @@ impl TunImpl {
     }
 }
 
+#[cfg(not(target_os = "windows"))]
+impl AsRawFd for TunImpl {
+    fn as_raw_fd(&self) -> RawFd {
+        self.tun.as_raw_fd()
+    }
+}
+
+#[cfg(not(target_os = "windows"))]
+impl AsFd for TunImpl {
+    fn as_fd(&self) -> BorrowedFd {
+        self.tun.as_fd()
+    }
+}
+
 pub(crate) struct TapImpl {
     tap: Tap,
 }
@@ -171,5 +187,19 @@ impl TapImpl {
     #[inline]
     pub fn recv(&self, buf: &mut [u8]) -> io::Result<usize> {
         self.tap.recv(buf)
+    }
+}
+
+#[cfg(not(target_os = "windows"))]
+impl AsFd for TapImpl {
+    fn as_fd(&self) -> BorrowedFd {
+        self.tap.as_fd()
+    }
+}
+
+#[cfg(not(target_os = "windows"))]
+impl AsRawFd for TapImpl {
+    fn as_raw_fd(&self) -> RawFd {
+        self.tap.as_raw_fd()
     }
 }

--- a/src/unix/tap.rs
+++ b/src/unix/tap.rs
@@ -9,7 +9,8 @@
 // except according to those terms.
 
 use std::net::IpAddr;
-
+#[cfg(not(target_os = "windows"))]
+use std::os::fd::{AsFd, AsRawFd, BorrowedFd};
 use std::{array, io, ptr};
 
 #[cfg(not(doc))]
@@ -446,6 +447,20 @@ impl Tap {
         unsafe {
             debug_assert_eq!(libc::close(fd), 0);
         }
+    }
+}
+
+#[cfg(not(target_os = "windows"))]
+impl AsFd for Tap {
+    fn as_fd(&self) -> BorrowedFd {
+        unsafe { BorrowedFd::borrow_raw(self.fd) }
+    }
+}
+
+#[cfg(not(target_os = "windows"))]
+impl AsRawFd for Tap {
+    fn as_raw_fd(&self) -> RawFd {
+        self.fd
     }
 }
 

--- a/src/unix/tun.rs
+++ b/src/unix/tun.rs
@@ -9,6 +9,8 @@
 // except according to those terms.
 
 use std::net::IpAddr;
+#[cfg(not(target_os = "windows"))]
+use std::os::fd::{AsFd, AsRawFd, BorrowedFd};
 use std::{array, io, ptr};
 
 use crate::RawFd;
@@ -547,6 +549,20 @@ impl Tun {
         unsafe {
             debug_assert_eq!(libc::close(fd), 0);
         }
+    }
+}
+
+#[cfg(not(target_os = "windows"))]
+impl AsFd for Tun {
+    fn as_fd(&self) -> BorrowedFd {
+        unsafe { BorrowedFd::borrow_raw(self.fd) }
+    }
+}
+
+#[cfg(not(target_os = "windows"))]
+impl AsRawFd for Tun {
+    fn as_raw_fd(&self) -> RawFd {
+        self.fd
     }
 }
 

--- a/src/wintun.rs
+++ b/src/wintun.rs
@@ -17,12 +17,12 @@ mod adapter;
 mod dll;
 mod session;
 
+use std::io;
+use std::ptr::NonNull;
+
 pub use adapter::TunAdapter;
 pub use dll::WintunLoggerCallback;
 pub use session::TunSession;
-
-use std::io;
-use std::ptr::NonNull;
 
 use dll::WintunSession;
 use windows_sys::Win32::Foundation::HANDLE;


### PR DESCRIPTION
This PR adds support for `tokio`, `mio`, `smol` and `async-std` runtimes.

Resolves #11