### PR TITLE
Remove non-windows requirement for `async-io`/`tokio`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -133,7 +133,7 @@
 // Show required OS/features on docs.rs.
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 
-#[cfg(any(doc, all(feature = "async-io", not(target_os = "windows"))))]
+#[cfg(any(doc, feature = "async-io"))]
 pub mod async_io;
 #[cfg(any(doc, target_os = "linux"))]
 pub mod linux;
@@ -141,7 +141,7 @@ pub mod linux;
 pub mod macos;
 #[cfg(any(doc, all(feature = "mio", not(target_os = "windows"))))]
 pub mod mio;
-#[cfg(any(doc, all(feature = "tokio", not(target_os = "windows"))))]
+#[cfg(any(doc, feature = "tokio"))]
 pub mod tokio;
 #[cfg(any(
     doc,
@@ -220,6 +220,7 @@ use rtnetlink::{
 ))]
 use sysctl::*;
 
+#[cfg(target_os = "linux")]
 const NETLINK_MAX_RECV: usize = 65536;
 
 pub type Netmask = u8;
@@ -336,32 +337,36 @@ pub enum AddAddress {
 }
 
 impl AddAddress {
+    /// The IP address associated with the interface.
     #[inline]
-    fn addr(&self) -> IpAddr {
+    pub fn addr(&self) -> IpAddr {
         match self {
             Self::V4(a) => a.addr.into(),
             Self::V6(a) => a.addr.into(),
         }
     }
 
+    /// The broadcast address associated with the interface.
     #[inline]
-    fn brd(&self) -> Option<IpAddr> {
+    pub fn brd(&self) -> Option<IpAddr> {
         match self {
             Self::V4(a) => Some(a.brd?.into()),
             Self::V6(a) => Some(a.brd?.into()),
         }
     }
 
+    /// The point-to-point destination address associated with the interface.
     #[inline]
-    fn dst(&self) -> Option<IpAddr> {
+    pub fn dst(&self) -> Option<IpAddr> {
         match self {
             Self::V4(a) => Some(a.dst?.into()),
             Self::V6(a) => Some(a.dst?.into()),
         }
     }
 
+    /// The netmask associated with the interface.
     #[inline]
-    fn netmask(&self) -> Option<Netmask> {
+    pub fn netmask(&self) -> Option<Netmask> {
         match self {
             Self::V4(a) => a.netmask,
             Self::V6(a) => a.netmask,
@@ -1669,7 +1674,7 @@ impl Interface {
         }
     }
 
-    #[cfg(not(target_os = "windows"))]
+    #[cfg(target_os = "linux")]
     #[inline]
     fn close_fd(fd: RawFd) {
         unsafe {

--- a/src/libc_extra.rs
+++ b/src/libc_extra.rs
@@ -856,14 +856,14 @@ pub const IF_FAKE_MEDIA_LIST_MAX: usize = 27;
 
 #[cfg(target_os = "macos")]
 pub const SIOCIFCREATE: libc::c_ulong = _IOWR::<ifreq>(b'i', 120);
-#[cfg(target_os = "macos")]
-pub const SIOCIFCREATE2: libc::c_ulong = _IOWR::<ifreq>(b'i', 122);
+//#[cfg(target_os = "macos")]
+//pub const SIOCIFCREATE2: libc::c_ulong = _IOWR::<ifreq>(b'i', 122);
 #[cfg(any(target_os = "openbsd", target_os = "netbsd"))]
 pub const SIOCIFCREATE: libc::c_ulong = _IOW::<ifreq>(b'i', 122);
 #[cfg(any(target_os = "dragonfly", target_os = "freebsd"))]
 pub const SIOCIFCREATE2: libc::c_ulong = _IOWR::<ifreq>(b'i', 124);
-#[cfg(target_os = "macos")]
-pub const SIOCGDRVSPEC: libc::c_ulong = _IOWR::<ifdrv>(b'i', 123);
+//#[cfg(target_os = "macos")]
+//pub const SIOCGDRVSPEC: libc::c_ulong = _IOWR::<ifdrv>(b'i', 123);
 #[cfg(target_os = "macos")]
 pub const SIOCSDRVSPEC: libc::c_ulong = _IOW::<ifdrv>(b'i', 123);
 #[cfg(any(

--- a/src/macos/utun.rs
+++ b/src/macos/utun.rs
@@ -41,15 +41,6 @@ pub struct iovec_const {
     pub iov_len: libc::size_t,
 }
 
-// MacOS `route` utility uses this buffer size
-#[cfg(not(doc))]
-#[repr(C)]
-#[allow(non_camel_case_types)]
-struct rtmsg {
-    m_rtm: libc::rt_msghdr,
-    m_space: [u8; 512],
-}
-
 pub struct Utun {
     fd: RawFd,
 }

--- a/src/mio/tap.rs
+++ b/src/mio/tap.rs
@@ -28,6 +28,7 @@ use mio::{Interest, Registry, Token};
 /// A cross-platform asynchronous TAP interface, suitable for tunnelling link-layer packets.
 pub struct AsyncTap {
     tap: Tap,
+    /// SAFETY: file descriptor/handle is closed when `tap` goes out of scope, so this doesn't need to.
     io: ManuallyDrop<UdpSocket>,
 }
 

--- a/src/tun.rs
+++ b/src/tun.rs
@@ -167,10 +167,15 @@ impl Tun {
         self.inner.recv(buf)
     }
 
-    /// The HANDLE
+    /// The HANDLE used to poll for incoming packet events in Windows.
+    ///
+    /// # Safety
+    ///
+    /// The returned handle must only be used in thread-safe contexts, and should not be used after
+    /// the `Tun` device is dropped.
     #[cfg(target_os = "windows")]
     #[inline]
-    pub fn read_handle(&mut self) -> HANDLE {
+    pub unsafe fn read_handle(&self) -> HANDLE {
         self.inner.read_handle()
     }
 }

--- a/src/wintun.rs
+++ b/src/wintun.rs
@@ -165,7 +165,7 @@ impl TunImpl {
     }
 
     #[inline]
-    pub fn read_handle(&mut self) -> HANDLE {
+    pub fn read_handle(&self) -> HANDLE {
         TunSession::read_handle_impl(&self.adapter, self.session.as_ptr())
     }
 }


### PR DESCRIPTION
Removes `cfg()` requirement barring windows from `tokio` and `async-io`. `mio` is currently still under testing for Windows, so it remains gated.