### PR TITLE
Fix arm build errors with libc::c_char

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,7 +219,7 @@ at the moment, but they are a planned feature for the near future.
 ## `async` Runtime Support
 
 All `Tun` and `Tap` types implement synchronous blocking/nonblocking `send()` and `recv()` APIs.
-In addition to this, `tappers` will aim to provide first-class support for the following `async`
+In addition to this, `tappers` provides first-class support for the following `async`
 runtimes:
 
 | `async` Runtime | Supported? |

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -724,7 +724,7 @@ impl Interface {
     #[cfg(not(target_os = "windows"))]
     #[inline]
     fn index_impl(&self) -> io::Result<u32> {
-        match unsafe { libc::if_nametoindex(self.name.as_ptr() as *const i8) } {
+        match unsafe { libc::if_nametoindex(self.name.as_ptr() as *const libc::c_char) } {
             0 => Err(io::Error::last_os_error()),
             i => Ok(i),
         }
@@ -770,10 +770,10 @@ impl Interface {
         self.name
     }
 
-    /// Returns the interface name as an array of `char` bytes (i.e. signed 8-bit integers).
+    /// Returns the interface name as an array of `char` bytes.
     #[cfg(any(doc, not(target_os = "windows")))]
-    pub fn name_raw_i8(&self) -> [i8; Self::MAX_INTERFACE_NAME_LEN + 1] {
-        array::from_fn(|i| self.name[i] as i8)
+    pub fn name_raw_char(&self) -> [libc::c_char; Self::MAX_INTERFACE_NAME_LEN + 1] {
+        array::from_fn(|i| self.name[i] as libc::c_char)
     }
 
     /// Returns the name associated with the given interface in C-string format.
@@ -788,7 +788,7 @@ impl Interface {
     #[cfg(any(doc, not(target_os = "windows")))]
     #[inline]
     pub fn name_cstr(&self) -> &CStr {
-        unsafe { CStr::from_ptr(self.name.as_ptr() as *const i8) }
+        unsafe { CStr::from_ptr(self.name.as_ptr() as *const libc::c_char) }
     }
 
     // An interface may have multiple assigned IP addresses. This is referred to as multihoming (see
@@ -1333,7 +1333,7 @@ impl Interface {
                     };
 
                 let mut req = ifaliasreq {
-                    ifra_name: self.name_raw_i8(),
+                    ifra_name: self.name_raw_char(),
                     #[cfg(not(target_os = "openbsd"))]
                     ifra_addr: addr,
                     #[cfg(target_os = "openbsd")]
@@ -1421,7 +1421,7 @@ impl Interface {
                     };
 
                 let mut req = in6_aliasreq {
-                    ifra_name: self.name_raw_i8(),
+                    ifra_name: self.name_raw_char(),
                     #[cfg(not(target_os = "openbsd"))]
                     ifra_addr: addr,
                     #[cfg(target_os = "openbsd")]
@@ -1619,7 +1619,7 @@ impl Interface {
                 let addr: libc::sockaddr = unsafe { mem::transmute(addr) };
 
                 let mut req = ifreq {
-                    ifr_name: self.name_raw_i8(),
+                    ifr_name: self.name_raw_char(),
                     ifr_ifru: __c_anonymous_ifr_ifru { ifru_addr: addr },
                 };
 
@@ -1655,7 +1655,7 @@ impl Interface {
                 };
 
                 let mut req = in6_ifreq {
-                    ifr_name: self.name_raw_i8(),
+                    ifr_name: self.name_raw_char(),
                     ifr_ifru: __c_anonymous_in6_ifr_ifru { ifru_addr: addr },
                 };
 

--- a/src/linux/tap.rs
+++ b/src/linux/tap.rs
@@ -70,7 +70,7 @@ impl Tap {
         let flags = libc::IFF_TAP | libc::IFF_NO_PI | libc::IFF_TUN_EXCL;
 
         let mut req = libc::ifreq {
-            ifr_name: if_name.name_raw_i8(),
+            ifr_name: if_name.name_raw_char(),
             ifr_ifru: libc::__c_anonymous_ifr_ifru {
                 ifru_flags: flags as i16,
             },
@@ -95,7 +95,7 @@ impl Tap {
         let flags = libc::IFF_TAP | libc::IFF_NO_PI | libc::IFF_TUN_EXCL;
 
         let mut req = libc::ifreq {
-            ifr_name: if_name.name_raw_i8(),
+            ifr_name: if_name.name_raw_char(),
             ifr_ifru: libc::__c_anonymous_ifr_ifru {
                 ifru_flags: flags as i16,
             },
@@ -154,9 +154,9 @@ impl Tap {
         let old_if_name = self.name()?;
 
         let mut req = libc::ifreq {
-            ifr_name: old_if_name.name_raw_i8(),
+            ifr_name: old_if_name.name_raw_char(),
             ifr_ifru: libc::__c_anonymous_ifr_ifru {
-                ifru_newname: if_name.name_raw_i8(),
+                ifru_newname: if_name.name_raw_char(),
             },
         };
 
@@ -229,7 +229,7 @@ impl Tap {
 
     /// Retrieves the Maximum Transmission Unit (MTU) of the TAP device.
     pub fn mtu(&self) -> io::Result<usize> {
-        let ifr_name = self.name()?.name_raw_i8();
+        let ifr_name = self.name()?.name_raw_char();
 
         let mut req = libc::ifreq {
             ifr_name,
@@ -265,7 +265,7 @@ impl Tap {
             return Err(io::Error::new(io::ErrorKind::InvalidInput, "MTU too large"));
         }
 
-        let ifr_name = self.name()?.name_raw_i8();
+        let ifr_name = self.name()?.name_raw_char();
 
         let mut req = libc::ifreq {
             ifr_name,

--- a/src/linux/tun.rs
+++ b/src/linux/tun.rs
@@ -69,7 +69,7 @@ impl Tun {
         let flags = libc::IFF_TUN | libc::IFF_NO_PI;
 
         let mut req = libc::ifreq {
-            ifr_name: if_name.name_raw_i8(),
+            ifr_name: if_name.name_raw_char(),
             ifr_ifru: libc::__c_anonymous_ifr_ifru {
                 ifru_flags: flags as i16,
             },
@@ -93,7 +93,7 @@ impl Tun {
         let flags = libc::IFF_TUN_EXCL | libc::IFF_TUN | libc::IFF_NO_PI;
 
         let mut req = libc::ifreq {
-            ifr_name: if_name.name_raw_i8(),
+            ifr_name: if_name.name_raw_char(),
             ifr_ifru: libc::__c_anonymous_ifr_ifru {
                 ifru_flags: flags as i16,
             },
@@ -151,9 +151,9 @@ impl Tun {
         let old_if_name = self.name()?;
 
         let mut req = libc::ifreq {
-            ifr_name: old_if_name.name_raw_i8(),
+            ifr_name: old_if_name.name_raw_char(),
             ifr_ifru: libc::__c_anonymous_ifr_ifru {
-                ifru_newname: if_name.name_raw_i8(),
+                ifru_newname: if_name.name_raw_char(),
             },
         };
 
@@ -227,7 +227,7 @@ impl Tun {
 
     /// Retrieves the Maximum Transmission Unit (MTU) of the TUN device.
     pub fn mtu(&self) -> io::Result<usize> {
-        let ifr_name = self.name()?.name_raw_i8();
+        let ifr_name = self.name()?.name_raw_char();
 
         let mut req = libc::ifreq {
             ifr_name,
@@ -254,7 +254,7 @@ impl Tun {
             return Err(io::Error::new(io::ErrorKind::InvalidInput, "MTU too large"));
         }
 
-        let ifr_name = self.name()?.name_raw_i8();
+        let ifr_name = self.name()?.name_raw_char();
 
         let mut req = libc::ifreq {
             ifr_name,

--- a/src/macos/feth.rs
+++ b/src/macos/feth.rs
@@ -18,9 +18,10 @@ use crate::libc_extra::*;
 use crate::RawFd;
 use crate::{AddAddress, AddressInfo, DeviceState, Interface, MacAddr};
 
-const DEV_BPF: *const i8 = b"/dev/bpf\0".as_ptr() as *const i8;
+const DEV_BPF: *const libc::c_char = b"/dev/bpf\0".as_ptr() as *const libc::c_char;
 const FETH_PREFIX: &[u8] = b"feth";
-const NET_LINK_FAKE_LRO: *const i8 = b"net.link.fake.lro\0".as_ptr() as *const i8;
+const NET_LINK_FAKE_LRO: *const libc::c_char =
+    b"net.link.fake.lro\0".as_ptr() as *const libc::c_char;
 
 const BPF_CREATE_ATTEMPTS: u32 = 1024;
 const BPF_BUFFER_LEN: i32 = 131072;
@@ -108,7 +109,7 @@ impl FethTap {
         // Create the primary `feth` device
 
         let mut req = libc::ifreq {
-            ifr_name: iface.name_raw_i8(),
+            ifr_name: iface.name_raw_char(),
             ifr_ifru: libc::__c_anonymous_ifr_ifru { ifru_flags: 0 },
         };
 
@@ -124,7 +125,7 @@ impl FethTap {
         // Create the peer `feth` device
 
         let mut peer_req = libc::ifreq {
-            ifr_name: peer_iface.name_raw_i8(),
+            ifr_name: peer_iface.name_raw_char(),
             ifr_ifru: libc::__c_anonymous_ifr_ifru { ifru_flags: 0 },
         };
 
@@ -143,7 +144,7 @@ impl FethTap {
         let mut fake_req = if_fake_request {
             iffr_reserved: [0u64; 4],
             iffr_u: __c_anonymous_iffr_u {
-                iffru_peer_name: peer_iface.name_raw_i8(),
+                iffru_peer_name: peer_iface.name_raw_char(),
             },
         };
 
@@ -366,7 +367,7 @@ impl FethTap {
     /// Returns the Maximum Transmission Unit (MTU) of the TAP device.
     pub fn mtu(&self) -> io::Result<usize> {
         let mut req = libc::ifreq {
-            ifr_name: self.iface.name_raw_i8(),
+            ifr_name: self.iface.name_raw_char(),
             ifr_ifru: libc::__c_anonymous_ifr_ifru {
                 ifru_devmtu: libc::ifdevmtu {
                     ifdm_current: 0,
@@ -388,7 +389,7 @@ impl FethTap {
     /// set to.
     pub fn min_mtu(&self) -> io::Result<usize> {
         let mut req = libc::ifreq {
-            ifr_name: self.iface.name_raw_i8(),
+            ifr_name: self.iface.name_raw_char(),
             ifr_ifru: libc::__c_anonymous_ifr_ifru {
                 ifru_devmtu: libc::ifdevmtu {
                     ifdm_current: 0,
@@ -410,7 +411,7 @@ impl FethTap {
     /// set to.
     pub fn max_mtu(&self) -> io::Result<usize> {
         let mut req = libc::ifreq {
-            ifr_name: self.iface.name_raw_i8(),
+            ifr_name: self.iface.name_raw_char(),
             ifr_ifru: libc::__c_anonymous_ifr_ifru {
                 ifru_devmtu: libc::ifdevmtu {
                     ifdm_current: 0,
@@ -438,7 +439,7 @@ impl FethTap {
         })?;
 
         let mut req = libc::ifreq {
-            ifr_name: self.iface.name_raw_i8(),
+            ifr_name: self.iface.name_raw_char(),
             ifr_ifru: libc::__c_anonymous_ifr_ifru { ifru_mtu: mtu },
         };
 
@@ -453,7 +454,7 @@ impl FethTap {
     /// Retrieves the current state of the TAP device (i.e. "up" or "down").
     pub fn state(&self) -> io::Result<DeviceState> {
         let mut req = libc::ifreq {
-            ifr_name: self.iface.name_raw_i8(),
+            ifr_name: self.iface.name_raw_char(),
             ifr_ifru: libc::__c_anonymous_ifr_ifru { ifru_flags: 0 },
         };
 
@@ -471,13 +472,13 @@ impl FethTap {
     /// Sets the adapter state of the TUN device (e.g. "up" or "down").
     pub fn set_state(&self, state: DeviceState) -> io::Result<()> {
         let mut req = libc::ifreq {
-            ifr_name: self.iface.name_raw_i8(),
+            ifr_name: self.iface.name_raw_char(),
             ifr_ifru: libc::__c_anonymous_ifr_ifru { ifru_flags: 0 },
         };
 
         /*
         let mut peer_req = libc::ifreq {
-            ifr_name: self.peer_iface.name_raw_i8(),
+            ifr_name: self.peer_iface.name_raw_char(),
             ifr_ifru: libc::__c_anonymous_ifr_ifru { ifru_flags: 0 },
         };
         */
@@ -523,7 +524,7 @@ impl FethTap {
     /// Indicates whether Address Resolution Protocol (ARP) is enabled on the Tap device.
     pub fn arp(&self) -> io::Result<bool> {
         let mut req = libc::ifreq {
-            ifr_name: self.iface.name_raw_i8(),
+            ifr_name: self.iface.name_raw_char(),
             ifr_ifru: libc::__c_anonymous_ifr_ifru { ifru_flags: 0 },
         };
 
@@ -541,12 +542,12 @@ impl FethTap {
     /// Enables or disables Address Resolution Protocol (ARP) on the Tap device.
     pub fn set_arp(&self, do_arp: bool) -> io::Result<()> {
         let mut req = libc::ifreq {
-            ifr_name: self.iface.name_raw_i8(),
+            ifr_name: self.iface.name_raw_char(),
             ifr_ifru: libc::__c_anonymous_ifr_ifru { ifru_flags: 0 },
         };
 
         let mut peer_req = libc::ifreq {
-            ifr_name: self.peer_iface.name_raw_i8(),
+            ifr_name: self.peer_iface.name_raw_char(),
             ifr_ifru: libc::__c_anonymous_ifr_ifru { ifru_flags: 0 },
         };
 
@@ -585,7 +586,7 @@ impl FethTap {
     /*
     pub fn debug(&self) -> io::Result<bool> {
         let mut req = libc::ifreq {
-            ifr_name: self.iface.name_raw_i8(),
+            ifr_name: self.iface.name_raw_char(),
             ifr_ifru: libc::__c_anonymous_ifr_ifru { ifru_flags: 0 },
         };
 
@@ -602,12 +603,12 @@ impl FethTap {
 
     pub fn set_debug(&self, do_debug: bool) -> io::Result<()> {
         let mut req = libc::ifreq {
-            ifr_name: self.iface.name_raw_i8(),
+            ifr_name: self.iface.name_raw_char(),
             ifr_ifru: libc::__c_anonymous_ifr_ifru { ifru_flags: 0 },
         };
 
         let mut peer_req = libc::ifreq {
-            ifr_name: self.peer_iface.name_raw_i8(),
+            ifr_name: self.peer_iface.name_raw_char(),
             ifr_ifru: libc::__c_anonymous_ifr_ifru { ifru_flags: 0 },
         };
 
@@ -647,7 +648,7 @@ impl FethTap {
     /*
     pub fn promiscuous(&self) -> io::Result<bool> {
         let mut req = libc::ifreq {
-            ifr_name: self.iface.name_raw_i8(),
+            ifr_name: self.iface.name_raw_char(),
             ifr_ifru: libc::__c_anonymous_ifr_ifru { ifru_flags: 0 },
         };
 
@@ -667,7 +668,7 @@ impl FethTap {
         // attached BPF.
 
         let mut req = libc::ifreq {
-            ifr_name: self.iface.name_raw_i8(),
+            ifr_name: self.iface.name_raw_char(),
             ifr_ifru: libc::__c_anonymous_ifr_ifru { ifru_flags: 0 },
         };
 
@@ -694,7 +695,7 @@ impl FethTap {
     /*
     pub fn lro(&self) -> io::Result<bool> {
         let mut req = libc::ifreq {
-            ifr_name: self.iface.name_raw_i8(),
+            ifr_name: self.iface.name_raw_char(),
             ifr_ifru: libc::__c_anonymous_ifr_ifru {
                 ifru_flags: 0,
             },
@@ -713,14 +714,14 @@ impl FethTap {
 
     pub fn set_lro(&self, do_lro: bool) -> io::Result<()> {
         let mut req = libc::ifreq {
-            ifr_name: self.iface.name_raw_i8(),
+            ifr_name: self.iface.name_raw_char(),
             ifr_ifru: libc::__c_anonymous_ifr_ifru {
                 ifru_flags: 0,
             },
         };
 
         let mut peer_req = libc::ifreq {
-            ifr_name: self.peer_iface.name_raw_i8(),
+            ifr_name: self.peer_iface.name_raw_char(),
             ifr_ifru: libc::__c_anonymous_ifr_ifru {
                 ifru_flags: 0,
             },
@@ -795,7 +796,7 @@ impl FethTap {
     /*
     pub fn ll_addr(&self) -> io::Result<MacAddr> {
         let mut req = libc::ifreq {
-            ifr_name: self.iface.name_raw_i8(),
+            ifr_name: self.iface.name_raw_char(),
             ifr_ifru: libc::__c_anonymous_ifr_ifru {
                 ifru_addr: libc::sockaddr {
                     sa_family: 0,
@@ -831,7 +832,7 @@ impl FethTap {
         };
 
         let mut req = libc::ifreq {
-            ifr_name: self.iface.name_raw_i8(),
+            ifr_name: self.iface.name_raw_char(),
             ifr_ifru: libc::__c_anonymous_ifr_ifru {
                 ifru_addr: libc::sockaddr {
                     sa_family: 0,
@@ -881,7 +882,7 @@ impl FethTap {
         };
 
         let mut req = libc::ifreq {
-            ifr_name: self.iface.name_raw_i8(),
+            ifr_name: self.iface.name_raw_char(),
             ifr_ifru: libc::__c_anonymous_ifr_ifru {
                 ifru_addr: libc::sockaddr {
                     sa_family: 0,
@@ -969,7 +970,7 @@ impl FethTap {
         Self::close_fd(self.bpf_fd);
 
         let mut peer_req = libc::ifreq {
-            ifr_name: self.peer_iface.name_raw_i8(),
+            ifr_name: self.peer_iface.name_raw_char(),
             ifr_ifru: libc::__c_anonymous_ifr_ifru { ifru_flags: 0 },
         };
 
@@ -979,7 +980,7 @@ impl FethTap {
         };
 
         let mut req = libc::ifreq {
-            ifr_name: self.iface.name_raw_i8(),
+            ifr_name: self.iface.name_raw_char(),
             ifr_ifru: libc::__c_anonymous_ifr_ifru { ifru_flags: 0 },
         };
 
@@ -1000,7 +1001,7 @@ impl FethTap {
 
     fn destroy_iface(sockfd: RawFd, iface: Interface) {
         let mut req = libc::ifreq {
-            ifr_name: iface.name_raw_i8(),
+            ifr_name: iface.name_raw_char(),
             ifr_ifru: libc::__c_anonymous_ifr_ifru { ifru_flags: 0 },
         };
 

--- a/src/macos/utun.rs
+++ b/src/macos/utun.rs
@@ -181,7 +181,7 @@ impl Utun {
         let if_name = self.name()?;
 
         let mut req = libc::ifreq {
-            ifr_name: if_name.name_raw_i8(),
+            ifr_name: if_name.name_raw_char(),
             ifr_ifru: libc::__c_anonymous_ifr_ifru {
                 ifru_devmtu: libc::ifdevmtu {
                     ifdm_current: 0,
@@ -204,7 +204,7 @@ impl Utun {
         let if_name = self.name()?;
 
         let mut req = libc::ifreq {
-            ifr_name: if_name.name_raw_i8(),
+            ifr_name: if_name.name_raw_char(),
             ifr_ifru: libc::__c_anonymous_ifr_ifru { ifru_flags: 0 },
         };
 
@@ -224,7 +224,7 @@ impl Utun {
         let if_name = self.name()?;
 
         let mut req = libc::ifreq {
-            ifr_name: if_name.name_raw_i8(),
+            ifr_name: if_name.name_raw_char(),
             ifr_ifru: libc::__c_anonymous_ifr_ifru { ifru_flags: 0 },
         };
 


### PR DESCRIPTION
Several libc functions and structs (such as `ifreq`) require a `libc::c_char` but were being passed an `i8`. This breaks certain architectures that define chars to be unsigned. This pull request aims to fix this issue.