### PR TITLE
Fix additional `i8` to `libc::c_char` implicit conversions

### DIFF
--- a/src/linux.rs
+++ b/src/linux.rs
@@ -23,7 +23,8 @@ use std::{io, net::IpAddr};
 
 use crate::{AddAddress, AddressInfo, DeviceState, Interface};
 
-pub(crate) const DEV_NET_TUN: *const i8 = b"/dev/net/tun\0".as_ptr() as *const i8;
+pub(crate) const DEV_NET_TUN: *const libc::c_char =
+    b"/dev/net/tun\0".as_ptr() as *const libc::c_char;
 
 // TODO: include Generic Receive Offset variant of Tun/Tap
 //

--- a/src/tap.rs
+++ b/src/tap.rs
@@ -172,7 +172,7 @@ mod tests {
     fn given_name() {
         use std::ffi::CStr;
 
-        let chosen_name = unsafe { CStr::from_ptr(b"feth24\0".as_ptr() as *const i8) };
+        let chosen_name = unsafe { CStr::from_ptr(b"feth24\0".as_ptr() as *const libc::c_char) };
 
         let iface = Interface::from_cstr(chosen_name).unwrap();
         let tun = Tap::new_named(iface).unwrap();
@@ -186,7 +186,7 @@ mod tests {
     fn given_name() {
         use std::ffi::CStr;
 
-        let chosen_name = unsafe { CStr::from_ptr(b"tap24\0".as_ptr() as *const i8) };
+        let chosen_name = unsafe { CStr::from_ptr(b"tap24\0".as_ptr() as *const libc::c_char) };
 
         let iface = Interface::from_cstr(chosen_name).unwrap();
         let tap = Tap::new_named(iface).unwrap();

--- a/src/tun.rs
+++ b/src/tun.rs
@@ -218,7 +218,7 @@ mod tests {
     fn given_name() {
         use std::ffi::CStr;
 
-        let chosen_name = unsafe { CStr::from_ptr(b"utun24\0".as_ptr() as *const i8) };
+        let chosen_name = unsafe { CStr::from_ptr(b"utun24\0".as_ptr() as *const libc::c_char) };
 
         let iface = Interface::from_cstr(chosen_name).unwrap();
         let tun = Tun::new_named(iface).unwrap();


### PR DESCRIPTION
A few more `i8` conversion fixes