### PR TITLE
Revise internal representation of `Interface` for Windows

### DIFF
--- a/.github/workflows/full_ci.yml
+++ b/.github/workflows/full_ci.yml
@@ -29,7 +29,7 @@ jobs:
       matrix:
         toolchain:
           - stable
-          - 1.70.0
+          - 1.74.0
     steps:
       - uses: actions/checkout@v4
       - name: Setup Rust toolchain
@@ -47,7 +47,7 @@ jobs:
       matrix:
         target:
           - { toolchain: stable, os: macos-14 }
-          - { toolchain: 1.70.0, os: macos-14 }
+          - { toolchain: 1.74.0, os: macos-14 }
     runs-on: ${{ matrix.target.os }}
     steps:
       - uses: actions/checkout@v4
@@ -66,7 +66,7 @@ jobs:
       matrix:
         toolchain:
           - stable
-          - 1.70.0
+          - 1.74.0
         target:
           - x86_64-pc-windows-msvc
     steps:
@@ -142,7 +142,7 @@ jobs:
       matrix:
         toolchain:
           - stable
-          - 1.70.0
+          - 1.74.0
     steps:
     - uses: actions/checkout@v4
     - name: Test in FreeBSD
@@ -171,7 +171,7 @@ jobs:
       matrix:
         toolchain:
           - stable
-          - 1.70.0
+          - 1.74.0
     steps:
     - uses: actions/checkout@v4
     - name: Test in NetBSD

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,8 +2,8 @@
 name = "tappers"
 authors = ["Nathaniel Bennett <me[at]nathanielbennett[dotcom]>"]
 description = "Cross-platform TUN, TAP and vETH interfaces"
-# 1.66 - `std::os::fd` stabilized
-rust-version = "1.70" 
+# 1.74 - `OsStr::as_encoded_bytes` stabilized
+rust-version = "1.74" 
 version = "0.4.2"
 license = "MIT OR Apache-2.0"
 edition = "2021"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -546,8 +546,7 @@ pub struct Interface {
     #[cfg(not(target_os = "windows"))]
     name: [u8; Self::MAX_INTERFACE_NAME_LEN + 1],
     #[cfg(target_os = "windows")]
-    name: [u16; Self::MAX_INTERFACE_NAME_LEN + 1],
-    is_catchall: bool,
+    name: [u8; Self::MAX_INTERFACE_NAME_LEN + 1],
 }
 
 impl Interface {
@@ -559,21 +558,6 @@ impl Interface {
     /// storing the interface name in an `Interface` instance, so the size of an `Interface` is
     /// likewise platform-dependent.
     pub const MAX_INTERFACE_NAME_LEN: usize = INTERNAL_MAX_INTERFACE_NAME_LEN;
-
-    /// A special catch-all interface identifier that specifies all operational interfaces.
-    ///
-    /// Note that this interface is not valid for most contexts--its main purpose is enabling raw
-    /// sockets or similar sniffing devices to listen in on traffic from all interfaces at once.
-    #[cfg(not(target_os = "windows"))]
-    pub fn any() -> io::Result<Self> {
-        let name = [0; Self::MAX_INTERFACE_NAME_LEN + 1];
-
-        // Leave the interface name blank since this is the catch-all identifier
-        Ok(Self {
-            name,
-            is_catchall: true,
-        })
-    }
 
     /// Constructs an `Interface` from the given interface name.
     ///
@@ -607,11 +591,8 @@ impl Interface {
 
     #[cfg(not(target_os = "windows"))]
     #[allow(unused)]
-    pub(crate) unsafe fn from_raw(arr: [u8; Self::MAX_INTERFACE_NAME_LEN + 1]) -> Self {
-        Self {
-            name: arr,
-            is_catchall: false,
-        }
+    pub(crate) unsafe fn from_raw(name: [u8; Self::MAX_INTERFACE_NAME_LEN + 1]) -> Self {
+        Self { name }
     }
 
     #[cfg(target_os = "windows")]
@@ -622,7 +603,6 @@ impl Interface {
 
         let interface = Interface {
             name,
-            is_catchall: false,
         };
 
         Ok(interface)
@@ -648,10 +628,7 @@ impl Interface {
         let mut name_iter = if_name.iter();
         let name = array::from_fn(|_| name_iter.next().cloned().unwrap_or(0));
 
-        Ok(Interface {
-            name,
-            is_catchall: false,
-        })
+        Ok(Interface { name })
     }
 
     /*
@@ -669,18 +646,10 @@ impl Interface {
     #[inline]
     #[cfg(not(target_os = "windows"))]
     pub fn from_index(if_index: u32) -> io::Result<Self> {
-        // TODO: do Unix systems other than Linux actually consider '0' to be a catch-all?
-        if if_index == 0 {
-            return Self::any();
-        }
-
         let mut name = [0u8; Self::MAX_INTERFACE_NAME_LEN + 1];
         match unsafe { libc::if_indextoname(if_index, name.as_mut_ptr() as *mut libc::c_char) } {
             ptr if ptr.is_null() => Err(io::Error::last_os_error()),
-            _ => Ok(Self {
-                name,
-                is_catchall: false,
-            }),
+            _ => Ok(Self { name }),
         }
     }
 

--- a/src/macos/utun.rs
+++ b/src/macos/utun.rs
@@ -175,7 +175,6 @@ impl Utun {
         } {
             0 => Ok(Interface {
                 name: name_buf,
-                is_catchall: false,
             }),
             _ => Err(io::Error::last_os_error()),
         }

--- a/src/wintun/adapter.rs
+++ b/src/wintun/adapter.rs
@@ -48,8 +48,8 @@ impl TunAdapter {
 
         let tunnel_type = "Tappers";
 
-        let name_utf16: Vec<u16> = if_name.name().encode_wide().collect();
-        let type_utf16: Vec<u16> = tunnel_type.encode_utf16().collect();
+        let name_utf16: Vec<u16> = if_name.name().encode_wide().chain(&[0]).collect();
+        let type_utf16: Vec<u16> = tunnel_type.encode_utf16().chain(&[0]).collect();
         let guid = Self::generate_guid(if_name, tunnel_type);
 
         let adapter = wintun.create_adapter(&name_utf16, &type_utf16, guid)?;


### PR DESCRIPTION
Currently, `Interface` is represented as an array of `u16` values. This unfortunately does not work very well with certain methods that expect a short char representation of an interface name rather than wide char. Since `OsStr` can be constructed directly from the short char representation, and since it can form the wide char representation directly as needed, we'll opt to make the internal a short char for now.