### PR TITLE
Fix `cargo doc` failure when used as a dependency

### DIFF
--- a/.github/workflows/full_ci.yml
+++ b/.github/workflows/full_ci.yml
@@ -29,7 +29,7 @@ jobs:
       matrix:
         toolchain:
           - stable
-          - 1.70.0
+          - 1.74.0
     steps:
       - uses: actions/checkout@v4
       - name: Setup Rust toolchain
@@ -47,7 +47,7 @@ jobs:
       matrix:
         target:
           - { toolchain: stable, os: macos-14 }
-          - { toolchain: 1.70.0, os: macos-14 }
+          - { toolchain: 1.74.0, os: macos-14 }
     runs-on: ${{ matrix.target.os }}
     steps:
       - uses: actions/checkout@v4
@@ -66,7 +66,7 @@ jobs:
       matrix:
         toolchain:
           - stable
-          - 1.70.0
+          - 1.74.0
         target:
           - x86_64-pc-windows-msvc
     steps:
@@ -142,7 +142,7 @@ jobs:
       matrix:
         toolchain:
           - stable
-          - 1.70.0
+          - 1.74.0
     steps:
     - uses: actions/checkout@v4
     - name: Test in FreeBSD
@@ -171,7 +171,7 @@ jobs:
       matrix:
         toolchain:
           - stable
-          - 1.70.0
+          - 1.74.0
     steps:
     - uses: actions/checkout@v4
     - name: Test in NetBSD

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,8 +2,8 @@
 name = "tappers"
 authors = ["Nathaniel Bennett <me[at]nathanielbennett[dotcom]>"]
 description = "Cross-platform TUN, TAP and vETH interfaces"
-# 1.66 - `std::os::fd` stabilized
-rust-version = "1.70" 
+# 1.74 - `OsStr::as_encoded_bytes` stabilized
+rust-version = "1.74"
 version = "0.4.2"
 license = "MIT OR Apache-2.0"
 edition = "2021"

--- a/ci/run.sh
+++ b/ci/run.sh
@@ -49,7 +49,8 @@ case "${OS}" in
 
         cargo test --all-targets --all-features
 
-        # doc tests must have all features enabled to run
+        cargo test --doc --features ""
+
         cargo test --doc --all-features
         ;;
     *)
@@ -67,7 +68,8 @@ case "${OS}" in
 
         cargo test --all-targets --all-features
 
-        # doc tests must have all features enabled to run
+        cargo test --doc --features ""
+
         cargo test --doc --all-features
         ;;
 esac

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(rustdoc::broken_intra_doc_links)]
+
 //! Tappers is a networking library that provides cross-platform support for TUN, TAP and virtual
 //! Ethernet (vETH) interfaces in Rust.
 //!
@@ -133,20 +135,19 @@
 // Show required OS/features on docs.rs.
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 
-#[cfg(any(doc, feature = "async-std"))]
+#[cfg(feature = "async-std")]
 pub mod async_std;
-#[cfg(any(doc, target_os = "linux"))]
+#[cfg(target_os = "linux")]
 pub mod linux;
-#[cfg(any(doc, target_os = "macos"))]
+#[cfg(target_os = "macos")]
 pub mod macos;
-#[cfg(any(doc, all(feature = "mio", not(target_os = "windows"))))]
+#[cfg(all(feature = "mio", not(target_os = "windows")))]
 pub mod mio;
-#[cfg(any(doc, feature = "smol"))]
+#[cfg(feature = "smol")]
 pub mod smol;
-#[cfg(any(doc, feature = "tokio"))]
+#[cfg(feature = "tokio")]
 pub mod tokio;
 #[cfg(any(
-    doc,
     target_os = "dragonfly",
     target_os = "freebsd",
 //    target_os = "illumos",
@@ -155,10 +156,10 @@ pub mod tokio;
 //    target_os = "solaris"
 ))]
 pub mod unix;
-#[cfg(any(doc, all(target_os = "windows", feature = "wintun")))]
+#[cfg(all(target_os = "windows", feature = "wintun"))]
 pub mod wintun;
 
-#[cfg(any(doc, not(target_os = "windows")))]
+#[cfg(not(target_os = "windows"))]
 mod libc_extra;
 #[cfg(target_os = "linux")]
 mod rtnetlink;
@@ -182,7 +183,7 @@ pub use tun::Tun;
 
 #[cfg(not(any(target_os = "linux", target_os = "windows")))]
 use std::cmp;
-#[cfg(any(doc, not(target_os = "windows")))]
+#[cfg(not(target_os = "windows"))]
 use std::ffi::CStr;
 use std::ffi::{OsStr, OsString};
 use std::fmt::{Debug, Display};
@@ -191,7 +192,7 @@ use std::mem;
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 #[cfg(not(target_os = "windows"))]
 use std::os::fd::RawFd;
-#[cfg(all(doc, target_os = "windows"))]
+#[cfg(target_os = "windows")]
 pub type RawFd = i32;
 #[cfg(not(target_os = "windows"))]
 use std::os::unix::ffi::OsStrExt;
@@ -546,8 +547,7 @@ pub struct Interface {
     #[cfg(not(target_os = "windows"))]
     name: [u8; Self::MAX_INTERFACE_NAME_LEN + 1],
     #[cfg(target_os = "windows")]
-    name: [u16; Self::MAX_INTERFACE_NAME_LEN + 1],
-    is_catchall: bool,
+    name: [u8; Self::MAX_INTERFACE_NAME_LEN + 1],
 }
 
 impl Interface {
@@ -560,26 +560,11 @@ impl Interface {
     /// likewise platform-dependent.
     pub const MAX_INTERFACE_NAME_LEN: usize = INTERNAL_MAX_INTERFACE_NAME_LEN;
 
-    /// A special catch-all interface identifier that specifies all operational interfaces.
-    ///
-    /// Note that this interface is not valid for most contexts--its main purpose is enabling raw
-    /// sockets or similar sniffing devices to listen in on traffic from all interfaces at once.
-    #[cfg(not(target_os = "windows"))]
-    pub fn any() -> io::Result<Self> {
-        let name = [0; Self::MAX_INTERFACE_NAME_LEN + 1];
-
-        // Leave the interface name blank since this is the catch-all identifier
-        Ok(Self {
-            name,
-            is_catchall: true,
-        })
-    }
-
     /// Constructs an `Interface` from the given interface name.
     ///
     /// `if_name` must not consist of more than
-    /// [`MAX_INTERFACE_NAME_LEN`](Self::MAX_INTERFACE_NAME_LEN) bytes of UTF-8 (for *nix
-    /// platforms) or, and must not contain any null characters.
+    /// [`MAX_INTERFACE_NAME_LEN`](Self::MAX_INTERFACE_NAME_LEN) bytes of UTF-8 and must not contain
+    /// any null characters.
     ///
     /// # Errors
     ///
@@ -587,7 +572,13 @@ impl Interface {
     /// number of bytes or contains a null character.
     #[inline]
     pub fn new(if_name: impl AsRef<OsStr>) -> io::Result<Self> {
-        Self::new_inner(if_name)
+        let bytes = if_name.as_ref().as_encoded_bytes();
+        if bytes.len() > Self::MAX_INTERFACE_NAME_LEN {
+            return Err(io::ErrorKind::InvalidInput.into());
+        }
+
+        let name = array::from_fn(|i| if i < bytes.len() { bytes[i] } else { 0 });
+        Ok(Interface { name })
     }
 
     /// Constructs an `Interface` from the given C string.
@@ -599,43 +590,12 @@ impl Interface {
     ///
     /// Returns [InvalidData](io::ErrorKind::InvalidData) if `if_name` is longer than the maximum
     /// number of bytes.
-    #[cfg(not(target_os = "windows"))]
     #[inline]
     pub fn from_cstr(if_name: &CStr) -> io::Result<Self> {
         Self::new_raw(if_name.to_bytes())
     }
 
-    #[cfg(not(target_os = "windows"))]
-    #[allow(unused)]
-    pub(crate) unsafe fn from_raw(arr: [u8; Self::MAX_INTERFACE_NAME_LEN + 1]) -> Self {
-        Self {
-            name: arr,
-            is_catchall: false,
-        }
-    }
-
-    #[cfg(target_os = "windows")]
-    #[inline]
-    fn new_inner(if_name: impl AsRef<OsStr>) -> io::Result<Self> {
-        let mut utf16 = if_name.as_ref().encode_wide();
-        let name = array::from_fn(|_| utf16.next().unwrap_or(0));
-
-        let interface = Interface {
-            name,
-            is_catchall: false,
-        };
-
-        Ok(interface)
-    }
-
-    #[cfg(not(target_os = "windows"))]
-    #[inline]
-    fn new_inner(if_name: impl AsRef<OsStr>) -> io::Result<Self> {
-        Self::new_raw(if_name.as_ref().as_bytes())
-    }
-
     // TODO: this should be `from_slice`
-    #[cfg(not(target_os = "windows"))]
     #[inline]
     fn new_raw(if_name: &[u8]) -> io::Result<Self> {
         if if_name.len() > Self::MAX_INTERFACE_NAME_LEN || if_name.contains(&0x00) {
@@ -648,10 +608,7 @@ impl Interface {
         let mut name_iter = if_name.iter();
         let name = array::from_fn(|_| name_iter.next().cloned().unwrap_or(0));
 
-        Ok(Interface {
-            name,
-            is_catchall: false,
-        })
+        Ok(Interface { name })
     }
 
     /*
@@ -669,18 +626,10 @@ impl Interface {
     #[inline]
     #[cfg(not(target_os = "windows"))]
     pub fn from_index(if_index: u32) -> io::Result<Self> {
-        // TODO: do Unix systems other than Linux actually consider '0' to be a catch-all?
-        if if_index == 0 {
-            return Self::any();
-        }
-
         let mut name = [0u8; Self::MAX_INTERFACE_NAME_LEN + 1];
         match unsafe { libc::if_indextoname(if_index, name.as_mut_ptr() as *mut libc::c_char) } {
             ptr if ptr.is_null() => Err(io::Error::last_os_error()),
-            _ => Ok(Self {
-                name,
-                is_catchall: false,
-            }),
+            _ => Ok(Self { name }),
         }
     }
 
@@ -771,7 +720,7 @@ impl Interface {
     }
 
     /// Returns the interface name as an array of `char` bytes.
-    #[cfg(any(doc, not(target_os = "windows")))]
+    #[cfg(not(target_os = "windows"))]
     pub fn name_raw_char(&self) -> [libc::c_char; Self::MAX_INTERFACE_NAME_LEN + 1] {
         array::from_fn(|i| self.name[i] as libc::c_char)
     }
@@ -785,7 +734,7 @@ impl Interface {
     ///
     /// Otherwise, a returned error indicates that [`Interface`] does not correspond to a valid
     /// interface.
-    #[cfg(any(doc, not(target_os = "windows")))]
+    #[cfg(not(target_os = "windows"))]
     #[inline]
     pub fn name_cstr(&self) -> &CStr {
         unsafe { CStr::from_ptr(self.name.as_ptr() as *const libc::c_char) }
@@ -794,7 +743,7 @@ impl Interface {
     // An interface may have multiple assigned IP addresses. This is referred to as multihoming (see
     // https://en.wikipedia.org/wiki/Multihoming).
 
-    #[cfg(any(doc, not(target_os = "windows")))]
+    #[cfg(not(target_os = "windows"))]
     #[inline]
     pub(crate) fn addrs(&self) -> io::Result<Vec<AddressInfo>> {
         self.addrs_impl() // GetAdaptersAddresses for Windows

--- a/src/macos/utun.rs
+++ b/src/macos/utun.rs
@@ -175,7 +175,6 @@ impl Utun {
         } {
             0 => Ok(Interface {
                 name: name_buf,
-                is_catchall: false,
             }),
             _ => Err(io::Error::last_os_error()),
         }

--- a/src/mio/tap.rs
+++ b/src/mio/tap.rs
@@ -130,7 +130,7 @@ impl AsyncTap {
     /// Receives a packet over the TAP device.
     #[inline]
     pub fn recv(&self, buf: &mut [u8]) -> io::Result<usize> {
-        self.io.recv(buf)
+        self.tap.recv(buf)
     }
 }
 

--- a/src/mio/tun.rs
+++ b/src/mio/tun.rs
@@ -140,7 +140,7 @@ impl AsyncTun {
     /// Receives a packet over the TUN device.
     #[inline]
     pub fn recv(&self, buf: &mut [u8]) -> io::Result<usize> {
-        self.io.recv(buf)
+        self.tun.recv(buf)
     }
 }
 

--- a/src/tokio/tap.rs
+++ b/src/tokio/tap.rs
@@ -169,7 +169,8 @@ impl AsyncTap {
 
             match guard.try_io(|inner| inner.get_ref().send(buf)) {
                 Ok(result) => return result,
-                Err(_would_block) => continue,
+                Err(e) if e.kind() == io::ErrorKind::WouldBlock => continue,
+                Err(e) => return Err(e),
             }
         }
     }
@@ -193,7 +194,8 @@ impl AsyncTap {
 
             match guard.try_io(|inner| inner.get_ref().recv(buf)) {
                 Ok(result) => return result,
-                Err(_would_block) => continue,
+                Err(e) if e.kind() == io::ErrorKind::WouldBlock => continue,
+                Err(e) => return Err(e),
             }
         }
     }

--- a/src/tokio/tun.rs
+++ b/src/tokio/tun.rs
@@ -70,7 +70,6 @@ impl AsyncTun {
     #[cfg(target_os = "windows")]
     fn new_impl() -> io::Result<Self> {
         let mut tun = Tun::new()?;
-        tun.set_nonblocking(true)?;
 
         Ok(Self {
             tun: TunWrapper(Arc::new(tun)),

--- a/src/wintun/adapter.rs
+++ b/src/wintun/adapter.rs
@@ -48,8 +48,8 @@ impl TunAdapter {
 
         let tunnel_type = "Tappers";
 
-        let name_utf16: Vec<u16> = if_name.name().encode_wide().collect();
-        let type_utf16: Vec<u16> = tunnel_type.encode_utf16().collect();
+        let name_utf16: Vec<u16> = if_name.name().encode_wide().chain(&[0]).collect();
+        let type_utf16: Vec<u16> = tunnel_type.encode_utf16().chain(&[0]).collect();
         let guid = Self::generate_guid(if_name, tunnel_type);
 
         let adapter = wintun.create_adapter(&name_utf16, &type_utf16, guid)?;


### PR DESCRIPTION
`cargo doc` fails to build when run without all features. This is due to the (now unused) addition of `doc` cfgs  that were once used to ensure all features showed up on docs.rs.

