### PR TITLE
Fix linux Tap::new_named() flags

### DIFF
--- a/src/linux/tap.rs
+++ b/src/linux/tap.rs
@@ -71,7 +71,7 @@ impl Tap {
         Ok(Self { fd })
     }
 
-    /// Opens or creates a TTAP device of the given name.
+    /// Opens or creates a TAP device of the given name.
     #[inline]
     pub fn new_named(if_name: Interface) -> io::Result<Self> {
         let flags = libc::IFF_TAP | libc::IFF_NO_PI | libc::IFF_TUN_EXCL;
@@ -97,7 +97,7 @@ impl Tap {
         Ok(Self { fd })
     }
 
-    /// Creates a new TTAP device, failing if a device of the given name already exists.
+    /// Creates a new TAP device, failing if a device of the given name already exists.
     pub fn create_named(if_name: Interface) -> io::Result<Self> {
         let flags = libc::IFF_TAP | libc::IFF_NO_PI | libc::IFF_TUN_EXCL;
 

--- a/src/linux/tap.rs
+++ b/src/linux/tap.rs
@@ -74,7 +74,7 @@ impl Tap {
     /// Opens or creates a TAP device of the given name.
     #[inline]
     pub fn new_named(if_name: Interface) -> io::Result<Self> {
-        let flags = libc::IFF_TAP | libc::IFF_NO_PI | libc::IFF_TUN_EXCL;
+        let flags = libc::IFF_TAP | libc::IFF_NO_PI;
 
         let mut req = libc::ifreq {
             ifr_name: if_name.name_raw_char(),

--- a/src/tap.rs
+++ b/src/tap.rs
@@ -41,7 +41,7 @@ impl Tap {
     // Note: Wintun TOCTOU? Only if other interface not created with Wintun but not `tappers`
     //
 
-    /// Creates a new, unique TUN device.
+    /// Creates a new, unique TAP device.
     #[inline]
     pub fn new() -> io::Result<Self> {
         Ok(Self {
@@ -49,7 +49,7 @@ impl Tap {
         })
     }
 
-    /// Opens or creates a TUN device of the given name.
+    /// Opens or creates a TAP device of the given name.
     #[inline]
     pub fn new_named(if_name: Interface) -> io::Result<Self> {
         Ok(Self {
@@ -57,7 +57,7 @@ impl Tap {
         })
     }
 
-    /// Retrieves the interface name of the TUN device.
+    /// Retrieves the interface name of the TAP device.
     #[inline]
     pub fn name(&self) -> io::Result<Interface> {
         self.inner.name()


### PR DESCRIPTION
`Tap::new_named()` would error if the given tap interface already existed on Linux, but the documentation says it should open existing devices. Removing the `IFF_TUN_EXCL` flag fixes the bug. Also fixed some errors in the docs.

Fixes #50, seems like that person had the same issue.