### PR TITLE
Bump version from 0.4.2 to 0.4.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ authors = ["Nathaniel Bennett <me[at]nathanielbennett[dotcom]>"]
 description = "Cross-platform TUN, TAP and vETH interfaces"
 # 1.66 - `std::os::fd` stabilized
 rust-version = "1.85" 
-version = "0.4.2"
+version = "0.4.3"
 license = "MIT OR Apache-2.0"
 edition = "2021"
 repository = "https://github.com/pkts-rs/tappers"


### PR DESCRIPTION
This version adds a patch for Tun::new_named() exclusive behavior and updates MSRV.